### PR TITLE
feat(API): Create c-like API skeleton

### DIFF
--- a/nixnet/dummy.py
+++ b/nixnet/dummy.py
@@ -1,6 +1,0 @@
-def dummy():
-    """Placeholder to help ensure everything is a-ok.
-
-    >>> dummy()
-    """
-    pass

--- a/nixnet/nx.py
+++ b/nixnet/nx.py
@@ -1,0 +1,254 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+
+def create_session(
+        database_name,
+        cluster_name,
+        list,
+        interface,
+        mode,
+        session_ref):
+    raise NotImplementedError("Placeholder")
+
+
+def create_session_by_ref(
+        number_of_database_ref,
+        array_of_database_ref,
+        interface,
+        mode,
+        session_ref):
+    raise NotImplementedError("Placeholder")
+
+
+def get_property(
+        session_ref,
+        property_id,
+        property_size,
+        property_value):
+    raise NotImplementedError("Placeholder")
+
+
+def get_property_size(
+        session_ref,
+        property_id,
+        property_size):
+    raise NotImplementedError("Placeholder")
+
+
+def set_property(
+        session_ref,
+        property_id,
+        property_size,
+        property_value):
+    raise NotImplementedError("Placeholder")
+
+
+def get_sub_property(
+        session_ref,
+        active_index,
+        property_id,
+        property_size,
+        property_value):
+    raise NotImplementedError("Placeholder")
+
+
+def get_sub_property_size(
+        session_ref,
+        active_index,
+        property_id,
+        property_size):
+    raise NotImplementedError("Placeholder")
+
+
+def set_sub_property(
+        session_ref,
+        active_index,
+        property_id,
+        property_size,
+        property_value):
+    raise NotImplementedError("Placeholder")
+
+
+def read_frame(
+        session_ref,
+        buffer,
+        size_of_buffer,
+        timeout,
+        number_of_bytes_returned):
+    raise NotImplementedError("Placeholder")
+
+
+def read_signal_single_point(
+        session_ref,
+        value_buffer,
+        size_of_value_buffer,
+        timestamp_buffer,
+        size_of_timestamp_buffer):
+    raise NotImplementedError("Placeholder")
+
+
+def read_signal_waveform(
+        session_ref,
+        timeout,
+        start_time,
+        delta_time,
+        value_buffer,
+        size_of_value_buffer,
+        number_of_values_returned):
+    raise NotImplementedError("Placeholder")
+
+
+def read_signal_xy(
+        session_ref,
+        time_limit,
+        value_buffer,
+        size_of_value_buffer,
+        timestamp_buffer,
+        size_of_timestamp_buffer,
+        num_pairs_buffer,
+        size_of_num_pairs_buffer):
+    raise NotImplementedError("Placeholder")
+
+
+def read_state(
+        session_ref,
+        state_id,
+        state_size,
+        state_value,
+        fault):
+    raise NotImplementedError("Placeholder")
+
+
+def write_frame(
+        session_ref,
+        buffer,
+        number_of_bytes_for_frames,
+        timeout):
+    raise NotImplementedError("Placeholder")
+
+
+def write_signal_single_point(
+        session_ref,
+        value_buffer,
+        size_of_value_buffer):
+    raise NotImplementedError("Placeholder")
+
+
+def write_state(
+        session_ref,
+        state_id,
+        state_size,
+        state_value):
+    raise NotImplementedError("Placeholder")
+
+
+def write_signal_waveform(
+        session_ref,
+        timeout,
+        value_buffer,
+        size_of_value_buffer):
+    raise NotImplementedError("Placeholder")
+
+
+def write_signal_xy(
+        session_ref,
+        timeout,
+        value_buffer,
+        size_of_value_buffer,
+        timestamp_buffer,
+        size_of_timestamp_buffer,
+        num_pairs_buffer,
+        size_of_num_pairs_buffer):
+    raise NotImplementedError("Placeholder")
+
+
+def convert_frames_to_signals_single_point(
+        session_ref,
+        frame_buffer,
+        number_of_bytes_for_frames,
+        value_buffer,
+        size_of_value_buffer,
+        timestamp_buffer,
+        size_of_timestamp_buffer):
+    raise NotImplementedError("Placeholder")
+
+
+def convert_signals_to_frames_single_point(
+        session_ref,
+        value_buffer,
+        size_of_value_buffer,
+        buffer,
+        size_of_buffer,
+        number_of_bytes_returned):
+    raise NotImplementedError("Placeholder")
+
+
+def blink(
+        interface_ref,
+        modifier):
+    raise NotImplementedError("Placeholder")
+
+
+def clear(
+        session_ref):
+    raise NotImplementedError("Placeholder")
+
+
+def connect_terminals(
+        session_ref,
+        source,
+        destination):
+    raise NotImplementedError("Placeholder")
+
+
+def disconnect_terminals(
+        session_ref,
+        source,
+        destination):
+    raise NotImplementedError("Placeholder")
+
+
+def flush(
+        session_ref):
+    raise NotImplementedError("Placeholder")
+
+
+def start(
+        session_ref,
+        scope):
+    raise NotImplementedError("Placeholder")
+
+
+def stop(
+        session_ref,
+        scope):
+    raise NotImplementedError("Placeholder")
+
+
+def status_to_string(
+        status,
+        sizeof_string,
+        status_description):
+    raise NotImplementedError("Placeholder")
+
+
+def system_open(
+        system_ref):
+    raise NotImplementedError("Placeholder")
+
+
+def system_close(
+        system_ref):
+    raise NotImplementedError("Placeholder")
+
+
+def wait(
+        session_ref,
+        condition,
+        param_in,
+        timeout,
+        param_out):
+    raise NotImplementedError("Placeholder")

--- a/nixnet/nxdb.py
+++ b/nixnet/nxdb.py
@@ -1,0 +1,144 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+
+def open_database(
+        database_name,
+        database_ref):
+    raise NotImplementedError("Placeholder")
+
+
+def close_database(
+        database_ref,
+        close_all_refs):
+    raise NotImplementedError("Placeholder")
+
+
+def create_object(
+        parent_object_ref,
+        object_class,
+        object_name,
+        db_object_ref):
+    raise NotImplementedError("Placeholder")
+
+
+def find_object(
+        parent_object_ref,
+        object_class,
+        object_name,
+        db_object_ref):
+    raise NotImplementedError("Placeholder")
+
+
+def delete_object(
+        db_object_ref):
+    raise NotImplementedError("Placeholder")
+
+
+def save_database(
+        database_ref,
+        db_filepath):
+    raise NotImplementedError("Placeholder")
+
+
+def get_property(
+        db_object_ref,
+        property_id,
+        property_size,
+        property_value):
+    raise NotImplementedError("Placeholder")
+
+
+def get_property_size(
+        db_object_ref,
+        property_id,
+        property_size):
+    raise NotImplementedError("Placeholder")
+
+
+def set_property(
+        db_object_ref,
+        property_id,
+        property_size,
+        property_value):
+    raise NotImplementedError("Placeholder")
+
+
+def get_dbc_attribute_size(
+        db_object_ref,
+        mode,
+        attribute_name,
+        attribute_text_size):
+    raise NotImplementedError("Placeholder")
+
+
+def get_dbc_attribute(
+        db_object_ref,
+        mode,
+        attribute_name,
+        attribute_text_size,
+        attribute_text,
+        is_default):
+    raise NotImplementedError("Placeholder")
+
+
+def merge(
+        target_cluster_ref,
+        source_obj_ref,
+        copy_mode,
+        prefix,
+        wait_for_complete,
+        percent_complete):
+    raise NotImplementedError("Placeholder")
+
+
+def add_alias(
+        database_alias,
+        database_filepath,
+        default_baud_rate):
+    raise NotImplementedError("Placeholder")
+
+
+def add_alias64(
+        database_alias,
+        database_filepath,
+        default_baud_rate):
+    raise NotImplementedError("Placeholder")
+
+
+def remove_alias(
+        database_alias):
+    raise NotImplementedError("Placeholder")
+
+
+def deploy(
+        ip_address,
+        database_alias,
+        wait_for_complete,
+        percent_complete):
+    raise NotImplementedError("Placeholder")
+
+
+def undeploy(
+        ip_address,
+        database_alias):
+    raise NotImplementedError("Placeholder")
+
+
+def get_database_list(
+        ip_address,
+        sizeof_alias_buffer,
+        alias_buffer,
+        sizeof_filepath_buffer,
+        filepath_buffer,
+        number_of_databases):
+    raise NotImplementedError("Placeholder")
+
+
+def get_database_list_sizes(
+        ip_address,
+        sizeof_alias_buffer,
+        sizeof_filepath_buffer):
+    raise NotImplementedError("Placeholder")


### PR DESCRIPTION
This attempts to capture all of the functions within the NI-XNET C API.
This will serve as the basis for designing an OOP API in #9.

Closes #4

- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nixnet-python/blob/master/CONTRIBUTING.rst).
- [x] New tests have been created for any new features or regression tests for bugfixes.
- [x] `tox` successfully runs, including unit tests and style checks (see [CONTRIBUTING.md](https://github.com/ni/nixnet-python/blob/master/CONTRIBUTING.rst)).