### PR TITLE
feat(CI): Configure travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+sudo: false
+language: python
+python:
+  - 2.7
+  - 3.4
+  - 3.5
+  - 3.6
+
+install:
+  - pip install -U tox-travis
+
+script:
+   - tox

--- a/tox.ini
+++ b/tox.ini
@@ -40,3 +40,7 @@ ignore = H903
 
 [pytest]
 addopts = --verbose --doctest-modules --ignore=setup.py
+
+[travis]
+python =
+  3.6: py36-test, flake8, docs


### PR DESCRIPTION
Leveraging tox-travis for running environments per-python version.

python 3.6 was arbitrarily chosen to run `flake8` and `docs` environments.