### PR TITLE
Errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .tox/
 __pycache__
 *.egg-info/
+*.pyc

--- a/nixnet/_errors.py
+++ b/nixnet/_errors.py
@@ -1,0 +1,29 @@
+﻿from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import ctypes
+import warnings
+
+from nixnet import _cconsts
+from nixnet import _cfuncs
+from nixnet import errors
+
+
+def check_for_error(error_code):
+    if error_code & _cconsts.NX_STATUS_ERROR:
+        buffer_size = 2048
+        error_buffer = ctypes.create_string_buffer(buffer_size)
+
+        _cfuncs.lib.nx_status_to_string(error_code, buffer_size, error_buffer)
+
+        raise errors.XnetError(error_buffer.value.decode("ascii"), error_code)
+    elif error_code != _cconsts.NX_SUCCESS:
+        buffer_size = 2048
+        error_buffer = ctypes.create_string_buffer(buffer_size)
+
+        _cfuncs.lib.nx_status_to_string(error_code, buffer_size, error_buffer)
+
+        warnings.warn(errors.XnetWarning(
+            error_buffer.value.decode("ascii"), error_code))

--- a/nixnet/_lib.py
+++ b/nixnet/_lib.py
@@ -7,36 +7,34 @@ from __future__ import unicode_literals
 import ctypes
 import sys
 
-
-class Error(Exception):
-    pass
+from nixnet import errors
 
 
-class PlatformUnsupportedError(Error):
+class PlatformUnsupportedError(errors.Error):
 
     def __init__(self, platform):
         message = '{0} is unsupported by this package.'.format(platform)
-        Error.__init__(self, message, platform)
+        super(PlatformUnsupportedError, self).__init__(message, platform)
 
 
-class XnetNotFoundError(Error):
+class XnetNotFoundError(errors.Error):
 
     def __init__(self, *args):
         message = (
             'Could not find an installation of NI-XNET. Please '
             'ensure that NI-XNET is installed on this machine or '
             'contact National Instruments for support.')
-        Error.__init__(self, message, *args)
+        super(XnetNotFoundError, self).__init__(message, *args)
 
 
-class XnetFunctionNotSupportedError(Error):
+class XnetFunctionNotSupportedError(errors.Error):
 
     def __init__(self, function):
         message = (
             'The NI-XNET function "{0}" is not supported in this '
             'version of NI-XNET. Visit ni.com/downloads to upgrade your '
             'version of NI-XNET.'.format(function))
-        Error.__init__(self, message, function)
+        super(XnetFunctionNotSupportedError, self).__init__(message, function)
 
 
 class XnetLibrary(object):

--- a/nixnet/_lib.py
+++ b/nixnet/_lib.py
@@ -50,7 +50,7 @@ class XnetLibrary(object):
             raise XnetFunctionNotSupportedError(function)
 
 
-def _import_win_lib(self):
+def _import_win_lib():
     lib_name = "nixnet"
     try:
         cdll = ctypes.cdll.LoadLibrary(lib_name)
@@ -59,7 +59,7 @@ def _import_win_lib(self):
     return XnetLibrary(cdll)
 
 
-def _import_unsupported(self):
+def _import_unsupported():
     raise PlatformUnsupportedError(sys.platform)
 
 

--- a/nixnet/errors.py
+++ b/nixnet/errors.py
@@ -1,0 +1,106 @@
+﻿from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import warnings
+
+from nixnet import _enums
+
+__all__ = ['XnetError', 'XnetWarning', 'XnetResourceWarning']
+
+
+class Error(Exception):
+    """Base error class for module."""
+    pass
+
+
+class XnetError(Error):
+    """Error raised by any NI-XNET method."""
+    def __init__(self, message, error_code):
+        """Initialize error.
+
+        Args:
+            message (string): Specifies the error message.
+            error_code (int): Specifies the NI-XNET error code.
+        """
+        super(XnetError, self).__init__(message)
+
+        self._error_code = error_code
+
+        try:
+            self._error_type = _enums.Err(self._error_code)
+        except ValueError:
+            self._error_type = _enums.Err.INTERNAL_ERROR
+
+    @property
+    def error_code(self):
+        """Error code reported by NI-XNET.
+
+        int: Specifies the NI-XNET error code.
+        """
+        return self._error_code
+
+    @property
+    def error_type(self):
+        """Error enum reported by NI-XNET.
+
+        :class:`nixnet._enums.Err`: Specifies the NI-XNET
+            error type.
+        """
+        return self._error_type
+
+
+class XnetWarning(Warning):
+    """Warning raised by any NI-XNET method."""
+    def __init__(self, message, error_code):
+        """Initialize warning.
+
+        Args:
+            message (string): Specifies the warning message.
+            error_code (int): Specifies the NI-DAQmx error code.
+        """
+        super(XnetWarning, self).__init__(
+            'Warning {0} occurred.\n\n{1}'.format(error_code, message))
+
+        self._error_code = error_code
+
+        try:
+            self._error_type = _enums.Warn(self._error_code)
+        except ValueError:
+            self._error_type = _enums.Err.INTERNAL_ERROR
+
+    @property
+    def error_code(self):
+        """Error code reported by NI-XNET.
+
+        int: Specifies the NI-XNET error code.
+        """
+        return self._error_code
+
+    @property
+    def error_type(self):
+        """Warning enum reported by NI-XNET.
+
+        :class:`nixnet._enums.Warn`: Specifies the NI-XNET
+            warning type.
+        """
+        return self._error_type
+
+
+class _ResourceWarning(Warning):
+    """Resource warning raised by any NI-XNET method.
+
+    Used in place of built-in ResourceWarning to allow Python 2.7 support.
+    """
+    pass
+
+
+# If ResourceWarning is in exceptions, it is also in the built-in namespace.
+try:
+    XnetResourceWarning = ResourceWarning
+except NameError:
+    XnetResourceWarning = _ResourceWarning
+
+warnings.filterwarnings("always", category=XnetWarning)
+warnings.filterwarnings("always", category=XnetResourceWarning)

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ setup(
         'enum34;python_version<"3.4"',
         'six'
     ],
-    tests_require=['pytest'],
+    tests_require=['pytest', 'mock'],
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "Intended Audience :: Developers",

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,4 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals

--- a/tests/test_dummy.py
+++ b/tests/test_dummy.py
@@ -1,2 +1,0 @@
-def test_dummy():
-    pass

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -3,7 +3,7 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
-import unittest.mock
+import mock
 
 import pytest
 
@@ -14,15 +14,15 @@ from nixnet import _errors
 from nixnet import errors
 
 
-MockXnetLibrary = unittest.mock.create_autospec(_cfuncs.XnetLibrary, spec_set=True, instance=True)
+MockXnetLibrary = mock.create_autospec(_cfuncs.XnetLibrary, spec_set=True, instance=True)
 
 
-@unittest.mock.patch('nixnet._cfuncs.lib', MockXnetLibrary)
+@mock.patch('nixnet._cfuncs.lib', MockXnetLibrary)
 def test_success():
     _errors.check_for_error(_cconsts.NX_SUCCESS)
 
 
-@unittest.mock.patch('nixnet._cfuncs.lib', MockXnetLibrary)
+@mock.patch('nixnet._cfuncs.lib', MockXnetLibrary)
 def test_known_error():
     with pytest.raises(errors.XnetError) as excinfo:
         _errors.check_for_error(_enums.Err.SELF_TEST_ERROR1.value)
@@ -31,7 +31,7 @@ def test_known_error():
     assert excinfo.value.args == ('', )
 
 
-@unittest.mock.patch('nixnet._cfuncs.lib', MockXnetLibrary)
+@mock.patch('nixnet._cfuncs.lib', MockXnetLibrary)
 def test_unknown_error():
     error_code = -201232  # Arbitrary number
     # Ensure it is an unknown error
@@ -47,7 +47,7 @@ def test_unknown_error():
     assert excinfo.value.args == ('', )
 
 
-@unittest.mock.patch('nixnet._cfuncs.lib', MockXnetLibrary)
+@mock.patch('nixnet._cfuncs.lib', MockXnetLibrary)
 def test_known_warning():
     with pytest.warns(errors.XnetWarning) as record:
         _errors.check_for_error(_enums.Warn.DATABASE_IMPORT.value)
@@ -57,7 +57,7 @@ def test_known_warning():
     assert record[0].message.args == ('Warning 1073098885 occurred.\n\n', )
 
 
-@unittest.mock.patch('nixnet._cfuncs.lib', MockXnetLibrary)
+@mock.patch('nixnet._cfuncs.lib', MockXnetLibrary)
 def test_unknown_warning():
     error_code = 201232  # Arbitrary number
     # Ensure it is an unknown error

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -1,0 +1,72 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import unittest.mock
+
+import pytest
+
+from nixnet import _cconsts
+from nixnet import _cfuncs
+from nixnet import _enums
+from nixnet import _errors
+from nixnet import errors
+
+
+MockXnetLibrary = unittest.mock.create_autospec(_cfuncs.XnetLibrary, spec_set=True, instance=True)
+
+
+@unittest.mock.patch('nixnet._cfuncs.lib', MockXnetLibrary)
+def test_success():
+    _errors.check_for_error(_cconsts.NX_SUCCESS)
+
+
+@unittest.mock.patch('nixnet._cfuncs.lib', MockXnetLibrary)
+def test_known_error():
+    with pytest.raises(errors.XnetError) as excinfo:
+        _errors.check_for_error(_enums.Err.SELF_TEST_ERROR1.value)
+    assert excinfo.value.error_code == _enums.Err.SELF_TEST_ERROR1.value
+    assert excinfo.value.error_type == _enums.Err.SELF_TEST_ERROR1
+    assert excinfo.value.args == ('', )
+
+
+@unittest.mock.patch('nixnet._cfuncs.lib', MockXnetLibrary)
+def test_unknown_error():
+    error_code = -201232  # Arbitrary number
+    # Ensure it is an unknown error
+    with pytest.raises(ValueError):
+        _enums.Err(error_code)
+
+    with pytest.raises(errors.XnetError) as excinfo:
+        _errors.check_for_error(error_code)
+    print(excinfo.value)
+    print(dir(excinfo.value))
+    assert excinfo.value.error_code == error_code
+    assert excinfo.value.error_type == _enums.Err.INTERNAL_ERROR
+    assert excinfo.value.args == ('', )
+
+
+@unittest.mock.patch('nixnet._cfuncs.lib', MockXnetLibrary)
+def test_known_warning():
+    with pytest.warns(errors.XnetWarning) as record:
+        _errors.check_for_error(_enums.Warn.DATABASE_IMPORT.value)
+    assert len(record) == 1
+    assert record[0].message.error_code == _enums.Warn.DATABASE_IMPORT.value
+    assert record[0].message.error_type == _enums.Warn.DATABASE_IMPORT
+    assert record[0].message.args == ('Warning 1073098885 occurred.\n\n', )
+
+
+@unittest.mock.patch('nixnet._cfuncs.lib', MockXnetLibrary)
+def test_unknown_warning():
+    error_code = 201232  # Arbitrary number
+    # Ensure it is an unknown error
+    with pytest.raises(ValueError):
+        _enums.Warn(error_code)
+
+    with pytest.warns(errors.XnetWarning) as record:
+        _errors.check_for_error(error_code)
+    assert len(record) == 1
+    assert record[0].message.error_code == error_code
+    assert record[0].message.error_type == _enums.Err.INTERNAL_ERROR
+    assert record[0].message.args == ('Warning 201232 occurred.\n\n', )

--- a/tox.ini
+++ b/tox.ini
@@ -12,6 +12,7 @@ commands =
     test: pytest {posargs}
 deps =
     pytest
+    mock
 
 [testenv:flake8]
 basepython = python3


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nixnet-python/blob/master/CONTRIBUTING.rst).
- [x] New tests have been created for any new features or regression tests for bugfixes.
- [x] `tox` successfully runs, including unit tests and style checks (see [CONTRIBUTING.md](https://github.com/ni/nixnet-python/blob/master/CONTRIBUTING.rst)).

### What does this Pull Request accomplish?

Defines an error API

### Why should this Pull Request be merged?

Stepping stone towards defining the API