### PR TITLE
feat(API): Add `Database` objects

### DIFF
--- a/nixnet/db/__init__.py
+++ b/nixnet/db/__init__.py
@@ -1,0 +1,10 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+
+from nixnet.db.database import Database
+
+
+__all__ = ["Database"]

--- a/nixnet/db/cluster.py
+++ b/nixnet/db/cluster.py
@@ -5,6 +5,7 @@ from __future__ import unicode_literals
 
 from nixnet import _funcs
 from nixnet import _props
+from nixnet import constants
 
 
 class Cluster(object):
@@ -92,11 +93,11 @@ class Cluster(object):
 
     @property
     def protocol(self):
-        return _props.get_cluster_protocol(self._handle)
+        return constants.Protocol(_props.get_cluster_protocol(self._handle))
 
     @protocol.setter
     def protocol(self, value):
-        _props.set_cluster_protocol(self._handle, value)
+        _props.set_cluster_protocol(self._handle, value.value)
 
     @property
     def sig_refs(self):
@@ -104,11 +105,11 @@ class Cluster(object):
 
     @property
     def can_io_mode(self):
-        return _props.get_cluster_can_io_mode(self._handle)
+        return constants.CaNioMode(_props.get_cluster_can_io_mode(self._handle))
 
     @can_io_mode.setter
     def can_io_mode(self, value):
-        _props.set_cluster_can_io_mode(self._handle, value)
+        _props.set_cluster_can_io_mode(self._handle, value.value)
 
     @property
     def can_fd_baud_rate(self):
@@ -416,12 +417,12 @@ class Cluster(object):
 
     @property
     def application_protocol(self):
-        return _props.get_cluster_application_protocol(self._handle)
+        return constants.AppProtocol(_props.get_cluster_application_protocol(self._handle))
 
     @application_protocol.setter
     def application_protocol(self, value):
-        _props.set_cluster_application_protocol(self._handle, value)
+        _props.set_cluster_application_protocol(self._handle, value.value)
 
     @property
     def can_fd_iso_mode(self):
-        return _props.get_cluster_can_fd_iso_mode(self._handle)
+        return constants.CanFdIsoMode(_props.get_cluster_can_fd_iso_mode(self._handle))

--- a/nixnet/db/cluster.py
+++ b/nixnet/db/cluster.py
@@ -1,0 +1,427 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+from nixnet import _funcs
+from nixnet import _props
+
+
+class Cluster(object):
+
+    def __init__(self, handle):
+        self._handle = handle
+
+    def __eq__(self, other):
+        if isinstance(other, self.__class__):
+            return self._handle == other._handle
+        return False
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
+
+    def __hash__(self):
+        return hash(self._handle)
+
+    def __repr__(self):
+        return 'Cluster(handle={0})'.format(self._handle)
+
+    def merge(
+            self,
+            source_obj,
+            copy_mode,
+            prefix,
+            wait_for_complete):
+        return _funcs.nxdb_merge(self._handle, source_obj._handle, copy_mode, prefix, wait_for_complete)
+
+    @property
+    def baud_rate(self):
+        return _props.get_cluster_baud_rate(self._handle)
+
+    @baud_rate.setter
+    def baud_rate(self, value):
+        _props.set_cluster_baud_rate(self._handle, value)
+
+    @property
+    def baud_rate64(self):
+        return _props.get_cluster_baud_rate64(self._handle)
+
+    @baud_rate64.setter
+    def baud_rate64(self, value):
+        _props.set_cluster_baud_rate64(self._handle, value)
+
+    @property
+    def comment(self):
+        return _props.get_cluster_comment(self._handle)
+
+    @comment.setter
+    def comment(self, value):
+        _props.set_cluster_comment(self._handle, value)
+
+    @property
+    def config_status(self):
+        return _props.get_cluster_config_status(self._handle)
+
+    @property
+    def database_ref(self):
+        return _props.get_cluster_database_ref(self._handle)
+
+    @property
+    def ecu_refs(self):
+        return _props.get_cluster_ecu_refs(self._handle)
+
+    @property
+    def frm_refs(self):
+        return _props.get_cluster_frm_refs(self._handle)
+
+    @property
+    def name(self):
+        return _props.get_cluster_name(self._handle)
+
+    @name.setter
+    def name(self, value):
+        _props.set_cluster_name(self._handle, value)
+
+    @property
+    def pdu_refs(self):
+        return _props.get_cluster_pdu_refs(self._handle)
+
+    @property
+    def pd_us_reqd(self):
+        return _props.get_cluster_pd_us_reqd(self._handle)
+
+    @property
+    def protocol(self):
+        return _props.get_cluster_protocol(self._handle)
+
+    @protocol.setter
+    def protocol(self, value):
+        _props.set_cluster_protocol(self._handle, value)
+
+    @property
+    def sig_refs(self):
+        return _props.get_cluster_sig_refs(self._handle)
+
+    @property
+    def can_io_mode(self):
+        return _props.get_cluster_can_io_mode(self._handle)
+
+    @can_io_mode.setter
+    def can_io_mode(self, value):
+        _props.set_cluster_can_io_mode(self._handle, value)
+
+    @property
+    def can_fd_baud_rate(self):
+        return _props.get_cluster_can_fd_baud_rate(self._handle)
+
+    @can_fd_baud_rate.setter
+    def can_fd_baud_rate(self, value):
+        _props.set_cluster_can_fd_baud_rate(self._handle, value)
+
+    @property
+    def can_fd_baud_rate64(self):
+        return _props.get_cluster_can_fd_baud_rate64(self._handle)
+
+    @can_fd_baud_rate64.setter
+    def can_fd_baud_rate64(self, value):
+        _props.set_cluster_can_fd_baud_rate64(self._handle, value)
+
+    @property
+    def flex_ray_act_pt_off(self):
+        return _props.get_cluster_flex_ray_act_pt_off(self._handle)
+
+    @flex_ray_act_pt_off.setter
+    def flex_ray_act_pt_off(self, value):
+        _props.set_cluster_flex_ray_act_pt_off(self._handle, value)
+
+    @property
+    def flex_ray_cas_rx_l_max(self):
+        return _props.get_cluster_flex_ray_cas_rx_l_max(self._handle)
+
+    @flex_ray_cas_rx_l_max.setter
+    def flex_ray_cas_rx_l_max(self, value):
+        _props.set_cluster_flex_ray_cas_rx_l_max(self._handle, value)
+
+    @property
+    def flex_ray_channels(self):
+        return _props.get_cluster_flex_ray_channels(self._handle)
+
+    @flex_ray_channels.setter
+    def flex_ray_channels(self, value):
+        _props.set_cluster_flex_ray_channels(self._handle, value)
+
+    @property
+    def flex_ray_clst_drift_dmp(self):
+        return _props.get_cluster_flex_ray_clst_drift_dmp(self._handle)
+
+    @flex_ray_clst_drift_dmp.setter
+    def flex_ray_clst_drift_dmp(self, value):
+        _props.set_cluster_flex_ray_clst_drift_dmp(self._handle, value)
+
+    @property
+    def flex_ray_cold_st_ats(self):
+        return _props.get_cluster_flex_ray_cold_st_ats(self._handle)
+
+    @flex_ray_cold_st_ats.setter
+    def flex_ray_cold_st_ats(self, value):
+        _props.set_cluster_flex_ray_cold_st_ats(self._handle, value)
+
+    @property
+    def flex_ray_cycle(self):
+        return _props.get_cluster_flex_ray_cycle(self._handle)
+
+    @flex_ray_cycle.setter
+    def flex_ray_cycle(self, value):
+        _props.set_cluster_flex_ray_cycle(self._handle, value)
+
+    @property
+    def flex_ray_dyn_seg_start(self):
+        return _props.get_cluster_flex_ray_dyn_seg_start(self._handle)
+
+    @property
+    def flex_ray_dyn_slot_idl_ph(self):
+        return _props.get_cluster_flex_ray_dyn_slot_idl_ph(self._handle)
+
+    @flex_ray_dyn_slot_idl_ph.setter
+    def flex_ray_dyn_slot_idl_ph(self, value):
+        _props.set_cluster_flex_ray_dyn_slot_idl_ph(self._handle, value)
+
+    @property
+    def flex_ray_latest_usable_dyn(self):
+        return _props.get_cluster_flex_ray_latest_usable_dyn(self._handle)
+
+    @property
+    def flex_ray_latest_guar_dyn(self):
+        return _props.get_cluster_flex_ray_latest_guar_dyn(self._handle)
+
+    @property
+    def flex_ray_lis_noise(self):
+        return _props.get_cluster_flex_ray_lis_noise(self._handle)
+
+    @flex_ray_lis_noise.setter
+    def flex_ray_lis_noise(self, value):
+        _props.set_cluster_flex_ray_lis_noise(self._handle, value)
+
+    @property
+    def flex_ray_macro_per_cycle(self):
+        return _props.get_cluster_flex_ray_macro_per_cycle(self._handle)
+
+    @flex_ray_macro_per_cycle.setter
+    def flex_ray_macro_per_cycle(self, value):
+        _props.set_cluster_flex_ray_macro_per_cycle(self._handle, value)
+
+    @property
+    def flex_ray_macrotick(self):
+        return _props.get_cluster_flex_ray_macrotick(self._handle)
+
+    @property
+    def flex_ray_max_wo_clk_cor_fat(self):
+        return _props.get_cluster_flex_ray_max_wo_clk_cor_fat(self._handle)
+
+    @flex_ray_max_wo_clk_cor_fat.setter
+    def flex_ray_max_wo_clk_cor_fat(self, value):
+        _props.set_cluster_flex_ray_max_wo_clk_cor_fat(self._handle, value)
+
+    @property
+    def flex_ray_max_wo_clk_cor_pas(self):
+        return _props.get_cluster_flex_ray_max_wo_clk_cor_pas(self._handle)
+
+    @flex_ray_max_wo_clk_cor_pas.setter
+    def flex_ray_max_wo_clk_cor_pas(self, value):
+        _props.set_cluster_flex_ray_max_wo_clk_cor_pas(self._handle, value)
+
+    @property
+    def flex_ray_minislot_act_pt(self):
+        return _props.get_cluster_flex_ray_minislot_act_pt(self._handle)
+
+    @flex_ray_minislot_act_pt.setter
+    def flex_ray_minislot_act_pt(self, value):
+        _props.set_cluster_flex_ray_minislot_act_pt(self._handle, value)
+
+    @property
+    def flex_ray_minislot(self):
+        return _props.get_cluster_flex_ray_minislot(self._handle)
+
+    @flex_ray_minislot.setter
+    def flex_ray_minislot(self, value):
+        _props.set_cluster_flex_ray_minislot(self._handle, value)
+
+    @property
+    def flex_ray_nm_vec_len(self):
+        return _props.get_cluster_flex_ray_nm_vec_len(self._handle)
+
+    @flex_ray_nm_vec_len.setter
+    def flex_ray_nm_vec_len(self, value):
+        _props.set_cluster_flex_ray_nm_vec_len(self._handle, value)
+
+    @property
+    def flex_ray_nit(self):
+        return _props.get_cluster_flex_ray_nit(self._handle)
+
+    @flex_ray_nit.setter
+    def flex_ray_nit(self, value):
+        _props.set_cluster_flex_ray_nit(self._handle, value)
+
+    @property
+    def flex_ray_nit_start(self):
+        return _props.get_cluster_flex_ray_nit_start(self._handle)
+
+    @property
+    def flex_ray_num_minislt(self):
+        return _props.get_cluster_flex_ray_num_minislt(self._handle)
+
+    @flex_ray_num_minislt.setter
+    def flex_ray_num_minislt(self, value):
+        _props.set_cluster_flex_ray_num_minislt(self._handle, value)
+
+    @property
+    def flex_ray_num_stat_slt(self):
+        return _props.get_cluster_flex_ray_num_stat_slt(self._handle)
+
+    @flex_ray_num_stat_slt.setter
+    def flex_ray_num_stat_slt(self, value):
+        _props.set_cluster_flex_ray_num_stat_slt(self._handle, value)
+
+    @property
+    def flex_ray_off_cor_st(self):
+        return _props.get_cluster_flex_ray_off_cor_st(self._handle)
+
+    @flex_ray_off_cor_st.setter
+    def flex_ray_off_cor_st(self, value):
+        _props.set_cluster_flex_ray_off_cor_st(self._handle, value)
+
+    @property
+    def flex_ray_payld_len_dyn_max(self):
+        return _props.get_cluster_flex_ray_payld_len_dyn_max(self._handle)
+
+    @flex_ray_payld_len_dyn_max.setter
+    def flex_ray_payld_len_dyn_max(self, value):
+        _props.set_cluster_flex_ray_payld_len_dyn_max(self._handle, value)
+
+    @property
+    def flex_ray_payld_len_max(self):
+        return _props.get_cluster_flex_ray_payld_len_max(self._handle)
+
+    @property
+    def flex_ray_payld_len_st(self):
+        return _props.get_cluster_flex_ray_payld_len_st(self._handle)
+
+    @flex_ray_payld_len_st.setter
+    def flex_ray_payld_len_st(self, value):
+        _props.set_cluster_flex_ray_payld_len_st(self._handle, value)
+
+    @property
+    def flex_ray_stat_slot(self):
+        return _props.get_cluster_flex_ray_stat_slot(self._handle)
+
+    @flex_ray_stat_slot.setter
+    def flex_ray_stat_slot(self, value):
+        _props.set_cluster_flex_ray_stat_slot(self._handle, value)
+
+    @property
+    def flex_ray_sym_win(self):
+        return _props.get_cluster_flex_ray_sym_win(self._handle)
+
+    @flex_ray_sym_win.setter
+    def flex_ray_sym_win(self, value):
+        _props.set_cluster_flex_ray_sym_win(self._handle, value)
+
+    @property
+    def flex_ray_sym_win_start(self):
+        return _props.get_cluster_flex_ray_sym_win_start(self._handle)
+
+    @property
+    def flex_ray_sync_node_max(self):
+        return _props.get_cluster_flex_ray_sync_node_max(self._handle)
+
+    @flex_ray_sync_node_max.setter
+    def flex_ray_sync_node_max(self, value):
+        _props.set_cluster_flex_ray_sync_node_max(self._handle, value)
+
+    @property
+    def flex_ray_tss_tx(self):
+        return _props.get_cluster_flex_ray_tss_tx(self._handle)
+
+    @flex_ray_tss_tx.setter
+    def flex_ray_tss_tx(self, value):
+        _props.set_cluster_flex_ray_tss_tx(self._handle, value)
+
+    @property
+    def flex_ray_wake_sym_rx_idl(self):
+        return _props.get_cluster_flex_ray_wake_sym_rx_idl(self._handle)
+
+    @flex_ray_wake_sym_rx_idl.setter
+    def flex_ray_wake_sym_rx_idl(self, value):
+        _props.set_cluster_flex_ray_wake_sym_rx_idl(self._handle, value)
+
+    @property
+    def flex_ray_wake_sym_rx_low(self):
+        return _props.get_cluster_flex_ray_wake_sym_rx_low(self._handle)
+
+    @flex_ray_wake_sym_rx_low.setter
+    def flex_ray_wake_sym_rx_low(self, value):
+        _props.set_cluster_flex_ray_wake_sym_rx_low(self._handle, value)
+
+    @property
+    def flex_ray_wake_sym_rx_win(self):
+        return _props.get_cluster_flex_ray_wake_sym_rx_win(self._handle)
+
+    @flex_ray_wake_sym_rx_win.setter
+    def flex_ray_wake_sym_rx_win(self, value):
+        _props.set_cluster_flex_ray_wake_sym_rx_win(self._handle, value)
+
+    @property
+    def flex_ray_wake_sym_tx_idl(self):
+        return _props.get_cluster_flex_ray_wake_sym_tx_idl(self._handle)
+
+    @flex_ray_wake_sym_tx_idl.setter
+    def flex_ray_wake_sym_tx_idl(self, value):
+        _props.set_cluster_flex_ray_wake_sym_tx_idl(self._handle, value)
+
+    @property
+    def flex_ray_wake_sym_tx_low(self):
+        return _props.get_cluster_flex_ray_wake_sym_tx_low(self._handle)
+
+    @flex_ray_wake_sym_tx_low.setter
+    def flex_ray_wake_sym_tx_low(self, value):
+        _props.set_cluster_flex_ray_wake_sym_tx_low(self._handle, value)
+
+    @property
+    def flex_ray_use_wakeup(self):
+        return _props.get_cluster_flex_ray_use_wakeup(self._handle)
+
+    @flex_ray_use_wakeup.setter
+    def flex_ray_use_wakeup(self, value):
+        _props.set_cluster_flex_ray_use_wakeup(self._handle, value)
+
+    @property
+    def lin_schedules(self):
+        return _props.get_cluster_lin_schedules(self._handle)
+
+    @property
+    def lin_tick(self):
+        return _props.get_cluster_lin_tick(self._handle)
+
+    @lin_tick.setter
+    def lin_tick(self, value):
+        _props.set_cluster_lin_tick(self._handle, value)
+
+    @property
+    def flex_ray_alw_pass_act(self):
+        return _props.get_cluster_flex_ray_alw_pass_act(self._handle)
+
+    @flex_ray_alw_pass_act.setter
+    def flex_ray_alw_pass_act(self, value):
+        _props.set_cluster_flex_ray_alw_pass_act(self._handle, value)
+
+    @property
+    def application_protocol(self):
+        return _props.get_cluster_application_protocol(self._handle)
+
+    @application_protocol.setter
+    def application_protocol(self, value):
+        _props.set_cluster_application_protocol(self._handle, value)
+
+    @property
+    def can_fd_iso_mode(self):
+        return _props.get_cluster_can_fd_iso_mode(self._handle)

--- a/nixnet/db/database.py
+++ b/nixnet/db/database.py
@@ -1,0 +1,73 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import warnings
+
+from nixnet import _funcs
+from nixnet import _props
+from nixnet import errors
+
+
+class Database(object):
+
+    def __init__(self, database_name):
+        self._handle = _funcs.nxdb_open_database(database_name)
+
+    def __del__(self):
+        if self._handle is not None:
+            warnings.warn(
+                'Database was not explicitly closed before it was destructed. '
+                'Resources on the device may still be reserved.',
+                errors.XnetResourceWarning)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self):
+        self.close()
+
+    def __eq__(self, other):
+        if isinstance(other, self.__class__):
+            return self._handle == other._handle
+        return False
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
+
+    def __hash__(self):
+        return hash(self._handle)
+
+    def __repr__(self):
+        return 'Database(handle={0})'.format(self._handle)
+
+    def close(self, close_all_refs=False):
+        if self._handle is None:
+            warnings.warn(
+                'Attempting to close NI-XNET system but system was already '
+                'closed', errors.XnetResourceWarning)
+            return
+
+        _funcs.nxdb_close_database(self._handle, close_all_refs)
+
+        self._handle = None
+
+    def save_database(self, db_filepath):
+        _funcs.nxdb_save_database(self._handle, db_filepath)
+
+    @property
+    def name(self):
+        return _props.get_database_name(self._handle)
+
+    @property
+    def clst_refs(self):
+        return _props.get_database_clst_refs(self._handle)
+
+    @property
+    def show_invalid_from_open(self):
+        return _props.get_database_show_invalid_from_open(self._handle)
+
+    @show_invalid_from_open.setter
+    def show_invalid_from_open(self, value):
+        _props.set_database_show_invalid_from_open(self._handle, value)

--- a/nixnet/db/ecu.py
+++ b/nixnet/db/ecu.py
@@ -1,0 +1,178 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+from nixnet import _props
+
+
+class Ecu(object):
+
+    def __init__(self, handle):
+        self._handle = handle
+
+    def __eq__(self, other):
+        if isinstance(other, self.__class__):
+            return self._handle == other._handle
+        return False
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
+
+    def __hash__(self):
+        return hash(self._handle)
+
+    def __repr__(self):
+        return 'Ecu(handle={0})'.format(self._handle)
+
+    @property
+    def clst_ref(self):
+        return _props.get_ecu_clst_ref(self._handle)
+
+    @property
+    def comment(self):
+        return _props.get_ecu_comment(self._handle)
+
+    @comment.setter
+    def comment(self, value):
+        _props.set_ecu_comment(self._handle, value)
+
+    @property
+    def config_status(self):
+        return _props.get_ecu_config_status(self._handle)
+
+    @property
+    def name(self):
+        return _props.get_ecu_name(self._handle)
+
+    @name.setter
+    def name(self, value):
+        _props.set_ecu_name(self._handle, value)
+
+    @property
+    def rx_frm_refs(self):
+        return _props.get_ecu_rx_frm_refs(self._handle)
+
+    @rx_frm_refs.setter
+    def rx_frm_refs(self, value):
+        _props.set_ecu_rx_frm_refs(self._handle, value)
+
+    @property
+    def tx_frm_refs(self):
+        return _props.get_ecu_tx_frm_refs(self._handle)
+
+    @tx_frm_refs.setter
+    def tx_frm_refs(self, value):
+        _props.set_ecu_tx_frm_refs(self._handle, value)
+
+    @property
+    def flex_ray_is_coldstart(self):
+        return _props.get_ecu_flex_ray_is_coldstart(self._handle)
+
+    @property
+    def flex_ray_startup_frame_ref(self):
+        return _props.get_ecu_flex_ray_startup_frame_ref(self._handle)
+
+    @property
+    def flex_ray_wakeup_ptrn(self):
+        return _props.get_ecu_flex_ray_wakeup_ptrn(self._handle)
+
+    @flex_ray_wakeup_ptrn.setter
+    def flex_ray_wakeup_ptrn(self, value):
+        _props.set_ecu_flex_ray_wakeup_ptrn(self._handle, value)
+
+    @property
+    def flex_ray_wakeup_chs(self):
+        return _props.get_ecu_flex_ray_wakeup_chs(self._handle)
+
+    @flex_ray_wakeup_chs.setter
+    def flex_ray_wakeup_chs(self, value):
+        _props.set_ecu_flex_ray_wakeup_chs(self._handle, value)
+
+    @property
+    def flex_ray_connected_chs(self):
+        return _props.get_ecu_flex_ray_connected_chs(self._handle)
+
+    @flex_ray_connected_chs.setter
+    def flex_ray_connected_chs(self, value):
+        _props.set_ecu_flex_ray_connected_chs(self._handle, value)
+
+    @property
+    def lin_master(self):
+        return _props.get_ecu_lin_master(self._handle)
+
+    @lin_master.setter
+    def lin_master(self, value):
+        _props.set_ecu_lin_master(self._handle, value)
+
+    @property
+    def lin_protocol_ver(self):
+        return _props.get_ecu_lin_protocol_ver(self._handle)
+
+    @lin_protocol_ver.setter
+    def lin_protocol_ver(self, value):
+        _props.set_ecu_lin_protocol_ver(self._handle, value)
+
+    @property
+    def lin_initial_nad(self):
+        return _props.get_ecu_lin_initial_nad(self._handle)
+
+    @lin_initial_nad.setter
+    def lin_initial_nad(self, value):
+        _props.set_ecu_lin_initial_nad(self._handle, value)
+
+    @property
+    def lin_config_nad(self):
+        return _props.get_ecu_lin_config_nad(self._handle)
+
+    @lin_config_nad.setter
+    def lin_config_nad(self, value):
+        _props.set_ecu_lin_config_nad(self._handle, value)
+
+    @property
+    def lin_supplier_id(self):
+        return _props.get_ecu_lin_supplier_id(self._handle)
+
+    @lin_supplier_id.setter
+    def lin_supplier_id(self, value):
+        _props.set_ecu_lin_supplier_id(self._handle, value)
+
+    @property
+    def lin_function_id(self):
+        return _props.get_ecu_lin_function_id(self._handle)
+
+    @lin_function_id.setter
+    def lin_function_id(self, value):
+        _props.set_ecu_lin_function_id(self._handle, value)
+
+    @property
+    def linp_2min(self):
+        return _props.get_ecu_linp_2min(self._handle)
+
+    @linp_2min.setter
+    def linp_2min(self, value):
+        _props.set_ecu_linp_2min(self._handle, value)
+
+    @property
+    def lins_tmin(self):
+        return _props.get_ecu_lins_tmin(self._handle)
+
+    @lins_tmin.setter
+    def lins_tmin(self, value):
+        _props.set_ecu_lins_tmin(self._handle, value)
+
+    @property
+    def j1939_preferred_address(self):
+        return _props.get_ecu_j1939_preferred_address(self._handle)
+
+    @j1939_preferred_address.setter
+    def j1939_preferred_address(self, value):
+        _props.set_ecu_j1939_preferred_address(self._handle, value)
+
+    @property
+    def j1939_node_name(self):
+        return _props.get_ecu_j1939_node_name(self._handle)
+
+    @j1939_node_name.setter
+    def j1939_node_name(self, value):
+        _props.set_ecu_j1939_node_name(self._handle, value)

--- a/nixnet/db/frame.py
+++ b/nixnet/db/frame.py
@@ -1,0 +1,246 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+from nixnet import _props
+
+
+class Frame(object):
+
+    def __init__(self, handle):
+        self._handle = handle
+
+    def __eq__(self, other):
+        if isinstance(other, self.__class__):
+            return self._handle == other._handle
+        return False
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
+
+    def __hash__(self):
+        return hash(self._handle)
+
+    def __repr__(self):
+        return 'Frame(handle={0})'.format(self._handle)
+
+    @property
+    def application_protocol(self):
+        return _props.get_frame_application_protocol(self._handle)
+
+    @application_protocol.setter
+    def application_protocol(self, value):
+        _props.set_frame_application_protocol(self._handle, value)
+
+    @property
+    def cluster_ref(self):
+        return _props.get_frame_cluster_ref(self._handle)
+
+    @property
+    def comment(self):
+        return _props.get_frame_comment(self._handle)
+
+    @comment.setter
+    def comment(self, value):
+        _props.set_frame_comment(self._handle, value)
+
+    @property
+    def config_status(self):
+        return _props.get_frame_config_status(self._handle)
+
+    @property
+    def default_payload(self):
+        return _props.get_frame_default_payload(self._handle)
+
+    @default_payload.setter
+    def default_payload(self, value):
+        _props.set_frame_default_payload(self._handle, value)
+
+    @property
+    def id(self):
+        return _props.get_frame_id(self._handle)
+
+    @id.setter
+    def id(self, value):
+        _props.set_frame_id(self._handle, value)
+
+    @property
+    def name(self):
+        return _props.get_frame_name(self._handle)
+
+    @name.setter
+    def name(self, value):
+        _props.set_frame_name(self._handle, value)
+
+    @property
+    def payload_len(self):
+        return _props.get_frame_payload_len(self._handle)
+
+    @payload_len.setter
+    def payload_len(self, value):
+        _props.set_frame_payload_len(self._handle, value)
+
+    @property
+    def sig_refs(self):
+        return _props.get_frame_sig_refs(self._handle)
+
+    @property
+    def can_ext_id(self):
+        return _props.get_frame_can_ext_id(self._handle)
+
+    @can_ext_id.setter
+    def can_ext_id(self, value):
+        _props.set_frame_can_ext_id(self._handle, value)
+
+    @property
+    def can_timing_type(self):
+        return _props.get_frame_can_timing_type(self._handle)
+
+    @can_timing_type.setter
+    def can_timing_type(self, value):
+        _props.set_frame_can_timing_type(self._handle, value)
+
+    @property
+    def can_tx_time(self):
+        return _props.get_frame_can_tx_time(self._handle)
+
+    @can_tx_time.setter
+    def can_tx_time(self, value):
+        _props.set_frame_can_tx_time(self._handle, value)
+
+    @property
+    def flex_ray_base_cycle(self):
+        return _props.get_frame_flex_ray_base_cycle(self._handle)
+
+    @flex_ray_base_cycle.setter
+    def flex_ray_base_cycle(self, value):
+        _props.set_frame_flex_ray_base_cycle(self._handle, value)
+
+    @property
+    def flex_ray_ch_assign(self):
+        return _props.get_frame_flex_ray_ch_assign(self._handle)
+
+    @flex_ray_ch_assign.setter
+    def flex_ray_ch_assign(self, value):
+        _props.set_frame_flex_ray_ch_assign(self._handle, value)
+
+    @property
+    def flex_ray_cycle_rep(self):
+        return _props.get_frame_flex_ray_cycle_rep(self._handle)
+
+    @flex_ray_cycle_rep.setter
+    def flex_ray_cycle_rep(self, value):
+        _props.set_frame_flex_ray_cycle_rep(self._handle, value)
+
+    @property
+    def flex_ray_preamble(self):
+        return _props.get_frame_flex_ray_preamble(self._handle)
+
+    @flex_ray_preamble.setter
+    def flex_ray_preamble(self, value):
+        _props.set_frame_flex_ray_preamble(self._handle, value)
+
+    @property
+    def flex_ray_startup(self):
+        return _props.get_frame_flex_ray_startup(self._handle)
+
+    @flex_ray_startup.setter
+    def flex_ray_startup(self, value):
+        _props.set_frame_flex_ray_startup(self._handle, value)
+
+    @property
+    def flex_ray_sync(self):
+        return _props.get_frame_flex_ray_sync(self._handle)
+
+    @flex_ray_sync.setter
+    def flex_ray_sync(self, value):
+        _props.set_frame_flex_ray_sync(self._handle, value)
+
+    @property
+    def flex_ray_timing_type(self):
+        return _props.get_frame_flex_ray_timing_type(self._handle)
+
+    @flex_ray_timing_type.setter
+    def flex_ray_timing_type(self, value):
+        _props.set_frame_flex_ray_timing_type(self._handle, value)
+
+    @property
+    def flex_ray_in_cyc_rep_enabled(self):
+        return _props.get_frame_flex_ray_in_cyc_rep_enabled(self._handle)
+
+    @property
+    def flex_ray_in_cyc_rep_i_ds(self):
+        return _props.get_frame_flex_ray_in_cyc_rep_i_ds(self._handle)
+
+    @flex_ray_in_cyc_rep_i_ds.setter
+    def flex_ray_in_cyc_rep_i_ds(self, value):
+        _props.set_frame_flex_ray_in_cyc_rep_i_ds(self._handle, value)
+
+    @property
+    def flex_ray_in_cyc_rep_ch_assigns(self):
+        return _props.get_frame_flex_ray_in_cyc_rep_ch_assigns(self._handle)
+
+    @flex_ray_in_cyc_rep_ch_assigns.setter
+    def flex_ray_in_cyc_rep_ch_assigns(self, value):
+        _props.set_frame_flex_ray_in_cyc_rep_ch_assigns(self._handle, value)
+
+    @property
+    def lin_checksum(self):
+        return _props.get_frame_lin_checksum(self._handle)
+
+    @property
+    def mux_is_muxed(self):
+        return _props.get_frame_mux_is_muxed(self._handle)
+
+    @property
+    def mux_data_mux_sig_ref(self):
+        return _props.get_frame_mux_data_mux_sig_ref(self._handle)
+
+    @property
+    def mux_static_sig_refs(self):
+        return _props.get_frame_mux_static_sig_refs(self._handle)
+
+    @property
+    def mux_subframe_refs(self):
+        return _props.get_frame_mux_subframe_refs(self._handle)
+
+    @property
+    def pdu_refs(self):
+        return _props.get_frame_pdu_refs(self._handle)
+
+    @pdu_refs.setter
+    def pdu_refs(self, value):
+        _props.set_frame_pdu_refs(self._handle, value)
+
+    @property
+    def pdu_start_bits(self):
+        return _props.get_frame_pdu_start_bits(self._handle)
+
+    @pdu_start_bits.setter
+    def pdu_start_bits(self, value):
+        _props.set_frame_pdu_start_bits(self._handle, value)
+
+    @property
+    def pdu_update_bits(self):
+        return _props.get_frame_pdu_update_bits(self._handle)
+
+    @pdu_update_bits.setter
+    def pdu_update_bits(self, value):
+        _props.set_frame_pdu_update_bits(self._handle, value)
+
+    @property
+    def variable_payload(self):
+        return _props.get_frame_variable_payload(self._handle)
+
+    @variable_payload.setter
+    def variable_payload(self, value):
+        _props.set_frame_variable_payload(self._handle, value)
+
+    @property
+    def ca_nio_mode(self):
+        return _props.get_frame_ca_nio_mode(self._handle)
+
+    @ca_nio_mode.setter
+    def ca_nio_mode(self, value):
+        _props.set_frame_ca_nio_mode(self._handle, value)

--- a/nixnet/db/frame.py
+++ b/nixnet/db/frame.py
@@ -4,6 +4,7 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 from nixnet import _props
+from nixnet import constants
 
 
 class Frame(object):
@@ -95,11 +96,11 @@ class Frame(object):
 
     @property
     def can_timing_type(self):
-        return _props.get_frame_can_timing_type(self._handle)
+        return constants.TimeType(_props.get_frame_can_timing_type(self._handle))
 
     @can_timing_type.setter
     def can_timing_type(self, value):
-        _props.set_frame_can_timing_type(self._handle, value)
+        _props.set_frame_can_timing_type(self._handle, value.value)
 
     @property
     def can_tx_time(self):
@@ -239,8 +240,8 @@ class Frame(object):
 
     @property
     def ca_nio_mode(self):
-        return _props.get_frame_ca_nio_mode(self._handle)
+        return constants.CaNioMode(_props.get_frame_ca_nio_mode(self._handle))
 
     @ca_nio_mode.setter
     def ca_nio_mode(self, value):
-        _props.set_frame_ca_nio_mode(self._handle, value)
+        _props.set_frame_ca_nio_mode(self._handle, value.value)

--- a/nixnet/db/linsched.py
+++ b/nixnet/db/linsched.py
@@ -4,6 +4,7 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 from nixnet import _props
+from nixnet import constants
 
 
 class LinSched(object):
@@ -63,8 +64,8 @@ class LinSched(object):
 
     @property
     def run_mode(self):
-        return _props.get_lin_sched_run_mode(self._handle)
+        return constants.LinSchedRunMode(_props.get_lin_sched_run_mode(self._handle))
 
     @run_mode.setter
     def run_mode(self, value):
-        _props.set_lin_sched_run_mode(self._handle, value)
+        _props.set_lin_sched_run_mode(self._handle, value.value)

--- a/nixnet/db/linsched.py
+++ b/nixnet/db/linsched.py
@@ -1,0 +1,70 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+from nixnet import _props
+
+
+class LinSched(object):
+
+    def __init__(self, handle):
+        self._handle = handle
+
+    def __eq__(self, other):
+        if isinstance(other, self.__class__):
+            return self._handle == other._handle
+        return False
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
+
+    def __hash__(self):
+        return hash(self._handle)
+
+    def __repr__(self):
+        return 'LinSched(handle={0})'.format(self._handle)
+
+    @property
+    def clst_ref(self):
+        return _props.get_lin_sched_clst_ref(self._handle)
+
+    @property
+    def comment(self):
+        return _props.get_lin_sched_comment(self._handle)
+
+    @comment.setter
+    def comment(self, value):
+        _props.set_lin_sched_comment(self._handle, value)
+
+    @property
+    def config_status(self):
+        return _props.get_lin_sched_config_status(self._handle)
+
+    @property
+    def entries(self):
+        return _props.get_lin_sched_entries(self._handle)
+
+    @property
+    def name(self):
+        return _props.get_lin_sched_name(self._handle)
+
+    @name.setter
+    def name(self, value):
+        _props.set_lin_sched_name(self._handle, value)
+
+    @property
+    def priority(self):
+        return _props.get_lin_sched_priority(self._handle)
+
+    @priority.setter
+    def priority(self, value):
+        _props.set_lin_sched_priority(self._handle, value)
+
+    @property
+    def run_mode(self):
+        return _props.get_lin_sched_run_mode(self._handle)
+
+    @run_mode.setter
+    def run_mode(self, value):
+        _props.set_lin_sched_run_mode(self._handle, value)

--- a/nixnet/db/linsched_entry.py
+++ b/nixnet/db/linsched_entry.py
@@ -4,6 +4,7 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 from nixnet import _props
+from nixnet import constants
 
 
 class LinSchedEntry(object):
@@ -75,11 +76,11 @@ class LinSchedEntry(object):
 
     @property
     def type(self):
-        return _props.get_lin_sched_entry_type(self._handle)
+        return constants.LinSchedEntryType(_props.get_lin_sched_entry_type(self._handle))
 
     @type.setter
     def type(self, value):
-        _props.set_lin_sched_entry_type(self._handle, value)
+        _props.set_lin_sched_entry_type(self._handle, value.value)
 
     @property
     def nc_ff_data_bytes(self):

--- a/nixnet/db/linsched_entry.py
+++ b/nixnet/db/linsched_entry.py
@@ -1,0 +1,90 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+from nixnet import _props
+
+
+class LinSchedEntry(object):
+
+    def __init__(self, handle):
+        self._handle = handle
+
+    def __eq__(self, other):
+        if isinstance(other, self.__class__):
+            return self._handle == other._handle
+        return False
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
+
+    def __hash__(self):
+        return hash(self._handle)
+
+    def __repr__(self):
+        return 'LinSchedEntry(handle={0})'.format(self._handle)
+
+    @property
+    def collision_res_sched(self):
+        return _props.get_lin_sched_entry_collision_res_sched(self._handle)
+
+    @collision_res_sched.setter
+    def collision_res_sched(self, value):
+        _props.set_lin_sched_entry_collision_res_sched(self._handle, value)
+
+    @property
+    def delay(self):
+        return _props.get_lin_sched_entry_delay(self._handle)
+
+    @delay.setter
+    def delay(self, value):
+        _props.set_lin_sched_entry_delay(self._handle, value)
+
+    @property
+    def event_id(self):
+        return _props.get_lin_sched_entry_event_id(self._handle)
+
+    @event_id.setter
+    def event_id(self, value):
+        _props.set_lin_sched_entry_event_id(self._handle, value)
+
+    @property
+    def frames(self):
+        return _props.get_lin_sched_entry_frames(self._handle)
+
+    @frames.setter
+    def frames(self, value):
+        _props.set_lin_sched_entry_frames(self._handle, value)
+
+    @property
+    def name(self):
+        return _props.get_lin_sched_entry_name(self._handle)
+
+    @name.setter
+    def name(self, value):
+        _props.set_lin_sched_entry_name(self._handle, value)
+
+    @property
+    def name_unique_to_cluster(self):
+        return _props.get_lin_sched_entry_name_unique_to_cluster(self._handle)
+
+    @property
+    def sched(self):
+        return _props.get_lin_sched_entry_sched(self._handle)
+
+    @property
+    def type(self):
+        return _props.get_lin_sched_entry_type(self._handle)
+
+    @type.setter
+    def type(self, value):
+        _props.set_lin_sched_entry_type(self._handle, value)
+
+    @property
+    def nc_ff_data_bytes(self):
+        return _props.get_lin_sched_entry_nc_ff_data_bytes(self._handle)
+
+    @nc_ff_data_bytes.setter
+    def nc_ff_data_bytes(self, value):
+        _props.set_lin_sched_entry_nc_ff_data_bytes(self._handle, value)

--- a/nixnet/db/pdu.py
+++ b/nixnet/db/pdu.py
@@ -1,0 +1,90 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+from nixnet import _props
+
+
+class Pdu(object):
+
+    def __init__(self, handle):
+        self._handle = handle
+
+    def __eq__(self, other):
+        if isinstance(other, self.__class__):
+            return self._handle == other._handle
+        return False
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
+
+    def __hash__(self):
+        return hash(self._handle)
+
+    def __repr__(self):
+        return 'Pdu(handle={0})'.format(self._handle)
+
+    @property
+    def cluster_ref(self):
+        return _props.get_pdu_cluster_ref(self._handle)
+
+    @property
+    def default_payload(self):
+        return _props.get_pdu_default_payload(self._handle)
+
+    @default_payload.setter
+    def default_payload(self, value):
+        _props.set_pdu_default_payload(self._handle, value)
+
+    @property
+    def comment(self):
+        return _props.get_pdu_comment(self._handle)
+
+    @comment.setter
+    def comment(self, value):
+        _props.set_pdu_comment(self._handle, value)
+
+    @property
+    def config_status(self):
+        return _props.get_pdu_config_status(self._handle)
+
+    @property
+    def frm_refs(self):
+        return _props.get_pdu_frm_refs(self._handle)
+
+    @property
+    def name(self):
+        return _props.get_pdu_name(self._handle)
+
+    @name.setter
+    def name(self, value):
+        _props.set_pdu_name(self._handle, value)
+
+    @property
+    def payload_len(self):
+        return _props.get_pdu_payload_len(self._handle)
+
+    @payload_len.setter
+    def payload_len(self, value):
+        _props.set_pdu_payload_len(self._handle, value)
+
+    @property
+    def sig_refs(self):
+        return _props.get_pdu_sig_refs(self._handle)
+
+    @property
+    def mux_is_muxed(self):
+        return _props.get_pdu_mux_is_muxed(self._handle)
+
+    @property
+    def mux_data_mux_sig_ref(self):
+        return _props.get_pdu_mux_data_mux_sig_ref(self._handle)
+
+    @property
+    def mux_static_sig_refs(self):
+        return _props.get_pdu_mux_static_sig_refs(self._handle)
+
+    @property
+    def mux_subframe_refs(self):
+        return _props.get_pdu_mux_subframe_refs(self._handle)

--- a/nixnet/db/signal.py
+++ b/nixnet/db/signal.py
@@ -4,6 +4,7 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 from nixnet import _props
+from nixnet import constants
 
 
 class Signal(object):
@@ -27,11 +28,11 @@ class Signal(object):
 
     @property
     def byte_ordr(self):
-        return _props.get_signal_byte_ordr(self._handle)
+        return constants.SigByteOrdr(_props.get_signal_byte_ordr(self._handle))
 
     @byte_ordr.setter
     def byte_ordr(self, value):
-        _props.set_signal_byte_ordr(self._handle, value)
+        _props.set_signal_byte_ordr(self._handle, value.value)
 
     @property
     def comment(self):
@@ -47,11 +48,11 @@ class Signal(object):
 
     @property
     def data_type(self):
-        return _props.get_signal_data_type(self._handle)
+        return constants.SigDataType(_props.get_signal_data_type(self._handle))
 
     @data_type.setter
     def data_type(self, value):
-        _props.set_signal_data_type(self._handle, value)
+        _props.set_signal_data_type(self._handle, value.value)
 
     @property
     def default(self):

--- a/nixnet/db/signal.py
+++ b/nixnet/db/signal.py
@@ -1,0 +1,158 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+from nixnet import _props
+
+
+class Signal(object):
+
+    def __init__(self, handle):
+        self._handle = handle
+
+    def __eq__(self, other):
+        if isinstance(other, self.__class__):
+            return self._handle == other._handle
+        return False
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
+
+    def __hash__(self):
+        return hash(self._handle)
+
+    def __repr__(self):
+        return 'Signal(handle={0})'.format(self._handle)
+
+    @property
+    def byte_ordr(self):
+        return _props.get_signal_byte_ordr(self._handle)
+
+    @byte_ordr.setter
+    def byte_ordr(self, value):
+        _props.set_signal_byte_ordr(self._handle, value)
+
+    @property
+    def comment(self):
+        return _props.get_signal_comment(self._handle)
+
+    @comment.setter
+    def comment(self, value):
+        _props.set_signal_comment(self._handle, value)
+
+    @property
+    def config_status(self):
+        return _props.get_signal_config_status(self._handle)
+
+    @property
+    def data_type(self):
+        return _props.get_signal_data_type(self._handle)
+
+    @data_type.setter
+    def data_type(self, value):
+        _props.set_signal_data_type(self._handle, value)
+
+    @property
+    def default(self):
+        return _props.get_signal_default(self._handle)
+
+    @default.setter
+    def default(self, value):
+        _props.set_signal_default(self._handle, value)
+
+    @property
+    def frame_ref(self):
+        return _props.get_signal_frame_ref(self._handle)
+
+    @property
+    def max(self):
+        return _props.get_signal_max(self._handle)
+
+    @max.setter
+    def max(self, value):
+        _props.set_signal_max(self._handle, value)
+
+    @property
+    def min(self):
+        return _props.get_signal_min(self._handle)
+
+    @min.setter
+    def min(self, value):
+        _props.set_signal_min(self._handle, value)
+
+    @property
+    def name(self):
+        return _props.get_signal_name(self._handle)
+
+    @name.setter
+    def name(self, value):
+        _props.set_signal_name(self._handle, value)
+
+    @property
+    def name_unique_to_cluster(self):
+        return _props.get_signal_name_unique_to_cluster(self._handle)
+
+    @property
+    def num_bits(self):
+        return _props.get_signal_num_bits(self._handle)
+
+    @num_bits.setter
+    def num_bits(self, value):
+        _props.set_signal_num_bits(self._handle, value)
+
+    @property
+    def pdu_ref(self):
+        return _props.get_signal_pdu_ref(self._handle)
+
+    @property
+    def scale_fac(self):
+        return _props.get_signal_scale_fac(self._handle)
+
+    @scale_fac.setter
+    def scale_fac(self, value):
+        _props.set_signal_scale_fac(self._handle, value)
+
+    @property
+    def scale_off(self):
+        return _props.get_signal_scale_off(self._handle)
+
+    @scale_off.setter
+    def scale_off(self, value):
+        _props.set_signal_scale_off(self._handle, value)
+
+    @property
+    def start_bit(self):
+        return _props.get_signal_start_bit(self._handle)
+
+    @start_bit.setter
+    def start_bit(self, value):
+        _props.set_signal_start_bit(self._handle, value)
+
+    @property
+    def unit(self):
+        return _props.get_signal_unit(self._handle)
+
+    @unit.setter
+    def unit(self, value):
+        _props.set_signal_unit(self._handle, value)
+
+    @property
+    def mux_is_data_mux(self):
+        return _props.get_signal_mux_is_data_mux(self._handle)
+
+    @mux_is_data_mux.setter
+    def mux_is_data_mux(self, value):
+        _props.set_signal_mux_is_data_mux(self._handle, value)
+
+    @property
+    def mux_is_dynamic(self):
+        return _props.get_signal_mux_is_dynamic(self._handle)
+
+    @property
+    def mux_value(self):
+        return _props.get_signal_mux_value(self._handle)
+
+    @property
+    def mux_subfrm_ref(self):
+        return _props.get_signal_mux_subfrm_ref(self._handle)

--- a/nixnet/db/subframe.py
+++ b/nixnet/db/subframe.py
@@ -1,0 +1,62 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+from nixnet import _props
+
+
+class SubFrame(object):
+
+    def __init__(self, handle):
+        self._handle = handle
+
+    def __eq__(self, other):
+        if isinstance(other, self.__class__):
+            return self._handle == other._handle
+        return False
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
+
+    def __hash__(self):
+        return hash(self._handle)
+
+    def __repr__(self):
+        return 'SubFrame(handle={0})'.format(self._handle)
+
+    @property
+    def config_status(self):
+        return _props.get_subframe_config_status(self._handle)
+
+    @property
+    def dyn_sig_refs(self):
+        return _props.get_subframe_dyn_sig_refs(self._handle)
+
+    @property
+    def frm_ref(self):
+        return _props.get_subframe_frm_ref(self._handle)
+
+    @property
+    def mux_value(self):
+        return _props.get_subframe_mux_value(self._handle)
+
+    @mux_value.setter
+    def mux_value(self, value):
+        _props.set_subframe_mux_value(self._handle, value)
+
+    @property
+    def name(self):
+        return _props.get_subframe_name(self._handle)
+
+    @name.setter
+    def name(self, value):
+        _props.set_subframe_name(self._handle, value)
+
+    @property
+    def pdu_ref(self):
+        return _props.get_subframe_pdu_ref(self._handle)
+
+    @property
+    def name_unique_to_cluster(self):
+        return _props.get_subframe_name_unique_to_cluster(self._handle)

--- a/nixnet/nxdb.py
+++ b/nixnet/nxdb.py
@@ -6,17 +6,6 @@ from __future__ import unicode_literals
 from nixnet import _funcs
 
 
-def open_database(
-        database_name):
-    return _funcs.nxdb_open_database(database_name)
-
-
-def close_database(
-        database_ref,
-        close_all_refs):
-    _funcs.nxdb_close_database(database_ref, close_all_refs)
-
-
 def create_object(
         parent_object_ref,
         object_class,
@@ -33,21 +22,6 @@ def find_object(
 
 def delete_object(db_object_ref):
     _funcs.nxdb_delete_object(db_object_ref)
-
-
-def save_database(
-        database_ref,
-        db_filepath):
-    _funcs.nxdb_save_database(database_ref, db_filepath)
-
-
-def merge(
-        target_cluster_ref,
-        source_obj_ref,
-        copy_mode,
-        prefix,
-        wait_for_complete):
-    return _funcs.nxdb_merge(target_cluster_ref, source_obj_ref, copy_mode, prefix, wait_for_complete)
 
 
 def add_alias64(


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nixnet-python/blob/master/CONTRIBUTING.rst).
- [ ] New tests have been created for any new features or regression tests for bugfixes.
- [x] `tox` successfully runs, including unit tests and style checks (see [CONTRIBUTING.md](https://github.com/ni/nixnet-python/blob/master/CONTRIBUTING.rst)).
- [x] Create an issue for `Frame` pdu properties are parallel arrays that should return  `namedtuple`s, see #53
- [x] Create an issue for There isn't an enum for `Ecu.lin_protocol_ver`, see #54
- [x] Create an issue for`flex_ray` enums are skipped again, like #47.  See #55
- [x] Create an issue for `Frames.ca_nio_mode` is incorrect.  See #56

### What does this Pull Request accomplish?

This adds properties to `Database` and all sub-objects.

In addition, database `save` and cluster `merge` are included.  Further
database organization is being deferred.

### Why should this Pull Request be merged?

This is a step to #9.

### What testing has been done?

None