### PR TITLE
fix(ctypes): Get examples mostly-running

### DIFF
--- a/nixnet/_frames.py
+++ b/nixnet/_frames.py
@@ -140,15 +140,16 @@ def iterate_frames(bytes):
 
 def serialize_frame(frame):
     """Yields units that compose the frame."""
-    base_unit_payload = frame.payload[0:MAX_BASE_UNIT_PAYLOAD_LENGTH]
+    payload = bytes(frame.payload)
+    base_unit_payload = payload[0:MAX_BASE_UNIT_PAYLOAD_LENGTH]
     base_unit_padding_length = max(MAX_BASE_UNIT_PAYLOAD_LENGTH - len(base_unit_payload), 0)
     base_unit_payload += b'\0' * base_unit_padding_length
 
-    payload_unit = frame.payload[MAX_BASE_UNIT_PAYLOAD_LENGTH:]
-    payload_unit_padding_length = _calculate_payload_unit_size(len(frame.payload)) - len(payload_unit)
+    payload_unit = payload[MAX_BASE_UNIT_PAYLOAD_LENGTH:]
+    payload_unit_padding_length = _calculate_payload_unit_size(len(payload)) - len(payload_unit)
     payload_unit += b'\0' * payload_unit_padding_length
 
-    payload_length = len(frame.payload)
+    payload_length = len(payload)
     if frame.type == constants.FrameType.J1939_DATA:
         if (frame.info & _cconsts.NX_FRAME_PAYLD_LEN_HIGH_MASK_J1939) != 0:
             # Invalid data where info_length will go.

--- a/nixnet/_funcs.py
+++ b/nixnet/_funcs.py
@@ -97,18 +97,18 @@ def nx_read_frame(
     timeout
 ):
     session_ref_ctypes = _ctypedefs.nxSessionRef_t(session_ref)
-    buffer_ctypes = (_ctypedefs.u8 * bytes_to_read)()
-    size_of_buffer_ctypes = _ctypedefs.u32(_ctypedefs.u8.BYTES * bytes_to_read)
-    number_of_bytes_returned_ctypes = ctypes.POINTER(_ctypedefs.u32)()
+    buffer_ctypes = (_ctypedefs.char * bytes_to_read)()
+    size_of_buffer_ctypes = _ctypedefs.u32(_ctypedefs.char.BYTES * bytes_to_read)
+    number_of_bytes_returned_ctypes = _ctypedefs.u32()
     timeout_ctypes = _ctypedefs.f64(timeout)
     result = _cfuncs.lib.nx_read_frame(
         session_ref_ctypes,
         buffer_ctypes,
         size_of_buffer_ctypes,
         timeout_ctypes,
-        number_of_bytes_returned_ctypes)
+        ctypes.pointer(number_of_bytes_returned_ctypes))
     _errors.check_for_error(result.value)
-    return buffer_ctypes.value, number_of_bytes_returned_ctypes.values
+    return buffer_ctypes.value, number_of_bytes_returned_ctypes.value
 
 
 def nx_read_signal_single_point(
@@ -137,10 +137,10 @@ def nx_write_frame(
     timeout
 ):
     session_ref_ctypes = _ctypedefs.nxSessionRef_t(session_ref)
-    buffer_ctypes = (_ctypedefs.u8 * len(buffer))(buffer)
-    size_of_buffer_ctypes = _ctypedefs.u32(_ctypedefs.u8.BYTES * len(buffer))
+    buffer_ctypes = (_ctypedefs.char * len(buffer))(*buffer)
+    size_of_buffer_ctypes = _ctypedefs.u32(_ctypedefs.char.BYTES * len(buffer))
     timeout_ctypes = _ctypedefs.f64(timeout)
-    result = _cfuncs.nx_write_frame(
+    result = _cfuncs.lib.nx_write_frame(
         session_ref_ctypes,
         buffer_ctypes,
         size_of_buffer_ctypes,

--- a/nixnet/nx.py
+++ b/nixnet/nx.py
@@ -140,28 +140,28 @@ class Session(object):
 
     def write_frame_bytes(
             self,
-            bytes,
+            frame_bytes,
             timeout=10):
         "http://zone.ni.com/reference/en-XX/help/372841N-01/nixnet/nxwriteframe/"
-        _funcs.nx_write_frame(self._handle, bytes, timeout)
+        _funcs.nx_write_frame(self._handle, bytes(frame_bytes), timeout)
 
     def write_raw_frame(
             self,
-            frames,
+            raw_frames,
             timeout=10):
         "http://zone.ni.com/reference/en-XX/help/372841N-01/nixnet/nxwriteframe/"
         units = itertools.chain.from_iterable(
             _frames.serialize_frame(frame)
-            for frame in frames)
+            for frame in raw_frames)
         bytes = b"".join(units)
         self.write_frame_bytes(bytes, timeout)
 
     def write_can_frame(
             self,
-            frames,
+            can_frames,
             timeout=10):
         "http://zone.ni.com/reference/en-XX/help/372841N-01/nixnet/nxwriteframe/"
-        raw_frames = (frame.to_raw() for frame in frames)
+        raw_frames = (frame.to_raw() for frame in can_frames)
         self.write_raw_frame(raw_frames, timeout)
 
     def write_signal_single_point(

--- a/nixnet_examples/can_frame_queued_io.py
+++ b/nixnet_examples/can_frame_queued_io.py
@@ -64,7 +64,7 @@ def main():
 
                 frame.payload = payload
                 output_session.write_can_frame([frame], write_timeout)
-                print('Sent frame with ID %s payload: %s' % (id, list(payload)))
+                print('Sent frame with ID %s payload: %s' % (id, payload))
 
                 # Wait 1 s and then read the received values.
                 # They should be the same as the ones sent.

--- a/nixnet_examples/can_frame_stream_io.py
+++ b/nixnet_examples/can_frame_stream_io.py
@@ -67,7 +67,7 @@ def main():
 
                 frame.payload = payload
                 output_session.write_can_frame([frame], write_timeout)
-                print('Sent frame with ID %s payload: %s' % (id, list(payload)))
+                print('Sent frame with ID %s payload: %s' % (id, payload))
 
                 # Wait 1 s and then read the received values.
                 # They should be the same as the ones sent.

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -1,0 +1,56 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import mock
+
+from nixnet import _cfuncs
+from nixnet import _ctypedefs
+
+from nixnet_examples import can_frame_queued_io
+from nixnet_examples import can_frame_stream_io
+from nixnet_examples import can_signal_single_point_io
+
+
+MockXnetLibrary = mock.create_autospec(_cfuncs.XnetLibrary, spec_set=True, instance=True)
+MockXnetLibrary.nx_create_session.return_value = _ctypedefs.u32(0)
+MockXnetLibrary.nx_set_property.return_value = _ctypedefs.u32(0)
+MockXnetLibrary.nx_start.return_value = _ctypedefs.u32(0)
+MockXnetLibrary.nx_write_frame.return_value = _ctypedefs.u32(0)
+MockXnetLibrary.nx_read_frame.return_value = _ctypedefs.u32(0)
+MockXnetLibrary.nx_write_signal_single_point.return_value = _ctypedefs.u32(0)
+MockXnetLibrary.nx_read_signal_single_point.return_value = _ctypedefs.u32(0)
+MockXnetLibrary.nx_stop.return_value = _ctypedefs.u32(0)
+MockXnetLibrary.nx_clear.return_value = _ctypedefs.u32(0)
+
+
+def six_input(queue):
+    queue.reverse()
+
+    def _six_input(prompt=""):
+        value = queue.pop()
+        return value
+
+    return _six_input
+
+
+@mock.patch('nixnet._cfuncs.lib', MockXnetLibrary)
+@mock.patch('six.moves.input', six_input(['y', '1, 2, 3', 'q']))
+@mock.patch('time.sleep', lambda time: None)
+def test_can_frame_queued_empty_session():
+    can_frame_queued_io.main()
+
+
+@mock.patch('nixnet._cfuncs.lib', MockXnetLibrary)
+@mock.patch('six.moves.input', six_input(['y', '1, 2, 3', 'q']))
+@mock.patch('time.sleep', lambda time: None)
+def test_can_frame_stream_empty_session():
+    can_frame_stream_io.main()
+
+
+@mock.patch('nixnet._cfuncs.lib', MockXnetLibrary)
+@mock.patch('six.moves.input', six_input(['y', '1, 2, 3', 'q']))
+@mock.patch('time.sleep', lambda time: None)
+def test_can_signal_single_point_empty_session():
+    can_signal_single_point_io.main()


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nixnet-python/blob/master/CONTRIBUTING.rst).
- [x] New tests have been created for any new features or regression tests for bugfixes.
- [x] `tox` successfully runs, including unit tests and style checks (see [CONTRIBUTING.md](https://github.com/ni/nixnet-python/blob/master/CONTRIBUTING.rst)).

### What does this Pull Request accomplish?

Fixes most bugs in the frame examples.  There is still some frame parsing as part of `read_can_frame` that isn't working.

### Why should this Pull Request be merged?

Getting everything closer to working

### What testing has been done?

Created and run tests with a mock library.  This doesn't return any data though.
