### PR TITLE
feat(API): Split `Session` into classes per-mode

### DIFF
--- a/nixnet/__init__.py
+++ b/nixnet/__init__.py
@@ -6,6 +6,6 @@ from __future__ import unicode_literals
 from nixnet.errors import XnetError  # NOQA: F401
 from nixnet.errors import XnetResourceWarning  # NOQA: F401
 from nixnet.errors import XnetWarning  # NOQA: F401
-from nixnet.session import Session  # NOQA: F401
+from nixnet.session import *  # NOQA: F401, F403
 
 __all__ = []

--- a/nixnet/_session/frames.py
+++ b/nixnet/_session/frames.py
@@ -3,9 +3,14 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
-from nixnet import _props
+import itertools
 
+from nixnet import _frames
+from nixnet import _funcs
+from nixnet import _props
 from nixnet._session import collection
+from nixnet import constants
+from nixnet import types
 
 
 class Frames(collection.Collection):
@@ -13,6 +18,98 @@ class Frames(collection.Collection):
 
     def __repr__(self):
         return 'Session.Frames(handle={0})'.format(self._handle)
+
+
+class InFrames(Frames):
+    """Frames in a session."""
+
+    def __repr__(self):
+        return 'Session.InFrames(handle={0})'.format(self._handle)
+
+    def read_bytes(
+            self,
+            number_of_bytes_to_read,
+            timeout=constants.TIMEOUT_NONE):
+        """Read frames.
+
+        Valid modes
+        - Frame Input Stream Mode
+        - Frame Input Queued Mode
+        - Frame Input Single-Point Mode
+        Frame: one or more
+        http://zone.ni.com/reference/en-XX/help/372841N-01/nixnet/nxreadframe/
+        """
+        buffer, number_of_bytes_returned = _funcs.nx_read_frame(self._handle, number_of_bytes_to_read, timeout)
+        return buffer[0:number_of_bytes_returned]
+
+    def read_raw(
+            self,
+            number_to_read,
+            timeout=constants.TIMEOUT_NONE):
+        """Read frames.
+
+        Valid modes
+        - Frame Input Stream Mode
+        - Frame Input Queued Mode
+        - Frame Input Single-Point Mode
+        Frame: one or more
+        http://zone.ni.com/reference/en-XX/help/372841N-01/nixnet/nxreadframe/
+        """
+        # NOTE: If the frame payload excedes the base unit, this will return
+        # less than number_to_read
+        number_of_bytes_to_read = number_to_read * _frames.nxFrameFixed_t.size
+        buffer = self.read_bytes(number_of_bytes_to_read, timeout)
+        for frame in _frames.iterate_frames(buffer):
+            yield frame
+
+    def read_can(
+            self,
+            number_to_read,
+            timeout=constants.TIMEOUT_NONE):
+        """Read frames.
+
+        Valid modes
+        - Frame Input Stream Mode
+        - Frame Input Queued Mode
+        - Frame Input Single-Point Mode
+        Frame: one or more
+        http://zone.ni.com/reference/en-XX/help/372841N-01/nixnet/nxreadframe/
+        """
+        for frame in self.read_raw(number_to_read, timeout):
+            yield types.CanFrame.from_raw(frame)
+
+
+class OutFrames(Frames):
+    """Frames in a session."""
+
+    def __repr__(self):
+        return 'Session.OutFrames(handle={0})'.format(self._handle)
+
+    def write_bytes(
+            self,
+            frame_bytes,
+            timeout=10):
+        "http://zone.ni.com/reference/en-XX/help/372841N-01/nixnet/nxwriteframe/"
+        _funcs.nx_write_frame(self._handle, bytes(frame_bytes), timeout)
+
+    def write_raw(
+            self,
+            raw_frames,
+            timeout=10):
+        "http://zone.ni.com/reference/en-XX/help/372841N-01/nixnet/nxwriteframe/"
+        units = itertools.chain.from_iterable(
+            _frames.serialize_frame(frame)
+            for frame in raw_frames)
+        bytes = b"".join(units)
+        self.write_bytes(bytes, timeout)
+
+    def write_can(
+            self,
+            can_frames,
+            timeout=10):
+        "http://zone.ni.com/reference/en-XX/help/372841N-01/nixnet/nxwriteframe/"
+        raw_frames = (frame.to_raw() for frame in can_frames)
+        self.write_raw(raw_frames, timeout)
 
 
 class Frame(collection.Item):

--- a/nixnet/_session/frames.py
+++ b/nixnet/_session/frames.py
@@ -79,6 +79,65 @@ class InFrames(Frames):
             yield types.CanFrame.from_raw(frame)
 
 
+class SinglePointInFrames(Frames):
+    """Frames in a session."""
+
+    def __repr__(self):
+        return 'Session.SinglePointInFrames(handle={0})'.format(self._handle)
+
+    def read_bytes(
+            self,
+            number_of_bytes_to_read,
+            timeout=constants.TIMEOUT_NONE):
+        """Read frames.
+
+        Valid modes
+        - Frame Input Stream Mode
+        - Frame Input Queued Mode
+        - Frame Input Single-Point Mode
+        Frame: one or more
+        http://zone.ni.com/reference/en-XX/help/372841N-01/nixnet/nxreadframe/
+        """
+        buffer, number_of_bytes_returned = _funcs.nx_read_frame(self._handle, number_of_bytes_to_read, timeout)
+        return buffer[0:number_of_bytes_returned]
+
+    def read_raw(
+            self,
+            timeout=constants.TIMEOUT_NONE):
+        """Read frames.
+
+        Valid modes
+        - Frame Input Stream Mode
+        - Frame Input Queued Mode
+        - Frame Input Single-Point Mode
+        Frame: one or more
+        http://zone.ni.com/reference/en-XX/help/372841N-01/nixnet/nxreadframe/
+        """
+        # NOTE: If the frame payload excedes the base unit, this will return
+        # less than number_to_read
+        number_to_read = len(self)
+        number_of_bytes_to_read = number_to_read * _frames.nxFrameFixed_t.size
+        buffer = self.read_bytes(number_of_bytes_to_read, timeout)
+        for frame in _frames.iterate_frames(buffer):
+            yield frame
+
+    def read_can(
+            self,
+            number_to_read,
+            timeout=constants.TIMEOUT_NONE):
+        """Read frames.
+
+        Valid modes
+        - Frame Input Stream Mode
+        - Frame Input Queued Mode
+        - Frame Input Single-Point Mode
+        Frame: one or more
+        http://zone.ni.com/reference/en-XX/help/372841N-01/nixnet/nxreadframe/
+        """
+        for frame in self.read_raw(number_to_read, timeout):
+            yield types.CanFrame.from_raw(frame)
+
+
 class OutFrames(Frames):
     """Frames in a session."""
 

--- a/nixnet/_session/signals.py
+++ b/nixnet/_session/signals.py
@@ -3,6 +3,8 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
+from nixnet import _funcs
+
 from nixnet._session import collection
 
 
@@ -11,6 +13,40 @@ class Signals(collection.Collection):
 
     def __repr__(self):
         return 'Session.Signals(handle={0})'.format(self._handle)
+
+
+class SinglePointInSignals(Signals):
+    """Writeable signals in a session."""
+
+    def __repr__(self):
+        return 'Session.SinglePointInSignals(handle={0})'.format(self._handle)
+
+    def read(self, num_signals):
+        """Read signal single point.
+
+        Valid modes
+        - Single Input Single-Point
+        Timestamps
+        - Optional in C API
+        - Timestamp per data point
+        http://zone.ni.com/reference/en-XX/help/372841N-01/nixnet/nxreadsignalsinglepoint/
+        """
+        timestamps, values = _funcs.nx_read_signal_single_point(self._handle, num_signals)
+        for timestamp, value in zip(timestamps, values):
+            yield timestamp.value, value.value
+
+
+class SinglePointOutSignals(Signals):
+    """Writeable signals in a session."""
+
+    def __repr__(self):
+        return 'Session.SinglePointOutSignals(handle={0})'.format(self._handle)
+
+    def write(
+            self,
+            value_buffer):
+        "http://zone.ni.com/reference/en-XX/help/372841N-01/nixnet/nxwritesignalsinglepoint/"
+        _funcs.nx_write_signal_single_point(self._handle, value_buffer)
 
 
 class Signal(collection.Item):

--- a/nixnet/_session/signals.py
+++ b/nixnet/_session/signals.py
@@ -21,7 +21,7 @@ class SinglePointInSignals(Signals):
     def __repr__(self):
         return 'Session.SinglePointInSignals(handle={0})'.format(self._handle)
 
-    def read(self, num_signals):
+    def read(self):
         """Read signal single point.
 
         Valid modes
@@ -31,6 +31,7 @@ class SinglePointInSignals(Signals):
         - Timestamp per data point
         http://zone.ni.com/reference/en-XX/help/372841N-01/nixnet/nxreadsignalsinglepoint/
         """
+        num_signals = len(self)
         timestamps, values = _funcs.nx_read_signal_single_point(self._handle, num_signals)
         for timestamp, value in zip(timestamps, values):
             yield timestamp.value, value.value

--- a/nixnet/_utils.py
+++ b/nixnet/_utils.py
@@ -1,0 +1,40 @@
+﻿from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import collections
+
+import six
+
+from nixnet import _cconsts
+from nixnet import _errors
+
+
+def flatten_items(list):
+    """Flatten an item list to a string
+
+    >>> flatten_items('Item')
+    'Item'
+    >>> flatten_items(['A', 'B'])
+    'A,B'
+    >>> flatten_items(None)
+    ''
+    """
+    if isinstance(list, six.string_types):
+        # For FRAME_IN_QUEUED / FRAME_OUT_QUEUED
+        # Convenience for everything else
+        if "," in list:
+            # A bit of an abuse of an error code
+            _errors.check_for_error(_cconsts.NX_ERR_INVALID_PROPERTY_VALUE)
+        flattened = list
+    elif isinstance(list, collections.Iterable):
+        flattened = ",".join(list)
+    elif list is None:
+        # For FRAME_IN_STREAM / FRAME_OUT_STREAM
+        flattened = ''
+    else:
+        # A bit of an abuse of an error code
+        _errors.check_for_error(_cconsts.NX_ERR_INVALID_PROPERTY_VALUE)
+
+    return flattened

--- a/nixnet/_utils.py
+++ b/nixnet/_utils.py
@@ -14,17 +14,17 @@ from nixnet import _errors
 def flatten_items(list):
     """Flatten an item list to a string
 
-    >>> flatten_items('Item')
+    >>> str(flatten_items('Item'))
     'Item'
-    >>> flatten_items(['A', 'B'])
+    >>> str(flatten_items(['A', 'B']))
     'A,B'
-    >>> flatten_items(None)
+    >>> str(flatten_items(None))
     ''
     """
     if isinstance(list, six.string_types):
         # For FRAME_IN_QUEUED / FRAME_OUT_QUEUED
         # Convenience for everything else
-        if "," in list:
+        if ',' in list:
             # A bit of an abuse of an error code
             _errors.check_for_error(_cconsts.NX_ERR_INVALID_PROPERTY_VALUE)
         flattened = list

--- a/nixnet/session.py
+++ b/nixnet/session.py
@@ -3,17 +3,13 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
-import collections
 import itertools
 import warnings
 
-import six
-
-from nixnet import _cconsts
-from nixnet import _errors
 from nixnet import _frames
 from nixnet import _funcs
 from nixnet import _props
+from nixnet import _utils
 from nixnet import constants
 from nixnet import errors
 from nixnet import types
@@ -34,20 +30,7 @@ class Session(object):
             interface,
             mode):
         "http://zone.ni.com/reference/en-XX/help/372841N-01/nixnet/nxcreatesession/"
-        if isinstance(list, six.string_types):
-            # For FRAME_IN_QUEUED / FRAME_OUT_QUEUED
-            # Convenience for everything else
-            if "," in list:
-                # A bit of an abuse of an error code
-                _errors.check_for_error(_cconsts.NX_ERR_INVALID_PROPERTY_VALUE)
-        elif isinstance(list, collections.Iterable):
-            list = ",".join(list)
-        elif list is None:
-            # For FRAME_IN_STREAM / FRAME_OUT_STREAM
-            list = ''
-        else:
-            # A bit of an abuse of an error code
-            _errors.check_for_error(_cconsts.NX_ERR_INVALID_PROPERTY_VALUE)
+        list = _utils.flatten_items(list)
         self._handle = None  # To satisfy `__del__` in case nx_create_session throws
         self._handle = _funcs.nx_create_session(database_name, cluster_name, list, interface, mode)
         self._frames = frames.Frames(self._handle)

--- a/nixnet/session.py
+++ b/nixnet/session.py
@@ -281,7 +281,7 @@ class FrameInSinglePointSession(SessionBase):
             flattened_list,
             interface,
             constants.CreateSessionMode.FRAME_IN_SINGLE_POINT)
-        self._frames = session_frames.InFrames(self._handle)
+        self._frames = session_frames.SinglePointInFrames(self._handle)
 
     @property
     def frames(self):

--- a/nixnet_examples/can_frame_queued_io.py
+++ b/nixnet_examples/can_frame_queued_io.py
@@ -18,14 +18,21 @@ pp = pprint.PrettyPrinter(indent=4)
 def main():
     database_name = 'NIXNET_example'
     cluster_name = 'CAN_Cluster'
-    list = 'CANEventFrame1'
+    input_frame = 'CANEventFrame1'
+    output_frame = 'CANEventFrame1'
     interface1 = 'CAN1'
     interface2 = 'CAN2'
-    input_mode = constants.CreateSessionMode.FRAME_IN_QUEUED
-    output_mode = constants.CreateSessionMode.FRAME_OUT_QUEUED
 
-    with nixnet.Session(database_name, cluster_name, list, interface1, input_mode) as input_session:
-        with nixnet.Session(database_name, cluster_name, list, interface2, output_mode) as output_session:
+    with nixnet.FrameInQueuedSession(
+            interface1,
+            database_name,
+            cluster_name,
+            input_frame) as input_session:
+        with nixnet.FrameOutQueuedSession(
+                interface2,
+                database_name,
+                cluster_name,
+                output_frame) as output_session:
             terminated_cable = six.moves.input('Are you using a terminated cable (Y or N)? ')
             if terminated_cable.lower() == "y":
                 input_session.intf.can_term = constants.CanTerm.ON
@@ -60,7 +67,7 @@ def main():
                     payload[index] = byte + i
 
                 frame.payload = payload
-                output_session.write_can_frame([frame])
+                output_session.frames.write_can([frame])
                 print('Sent frame with ID %s payload: %s' % (id, payload))
 
                 # Wait 1 s and then read the received values.
@@ -68,7 +75,7 @@ def main():
                 time.sleep(1)
 
                 count = 1
-                frames = input_session.read_can_frame(count)
+                frames = input_session.frames.read_can(count)
                 for frame in frames:
                     print('Received frame: ')
                     pp.pprint(frame)

--- a/nixnet_examples/can_frame_stream_io.py
+++ b/nixnet_examples/can_frame_stream_io.py
@@ -16,16 +16,11 @@ pp = pprint.PrettyPrinter(indent=4)
 
 
 def main():
-    database_name = ':memory:'
-    cluster_name = ''
-    list = ''
     interface1 = 'CAN1'
     interface2 = 'CAN2'
-    input_mode = constants.CreateSessionMode.FRAME_IN_STREAM
-    output_mode = constants.CreateSessionMode.FRAME_OUT_STREAM
 
-    with nixnet.Session(database_name, cluster_name, list, interface1, input_mode) as input_session:
-        with nixnet.Session(database_name, cluster_name, list, interface2, output_mode) as output_session:
+    with nixnet.FrameInStreamSession(interface1) as input_session:
+        with nixnet.FrameOutStreamSession(interface2) as output_session:
             terminated_cable = six.moves.input('Are you using a terminated cable (Y or N)? ')
             if terminated_cable.lower() == "y":
                 input_session.intf.can_term = constants.CanTerm.ON
@@ -64,7 +59,7 @@ def main():
                     payload[index] = byte + i
 
                 frame.payload = payload
-                output_session.write_can_frame([frame])
+                output_session.frames.write_can([frame])
                 print('Sent frame with ID %s payload: %s' % (id, payload))
 
                 # Wait 1 s and then read the received values.
@@ -72,7 +67,7 @@ def main():
                 time.sleep(1)
 
                 count = 1
-                frames = input_session.read_can_frame(count)
+                frames = input_session.frames.read_can(count)
                 for frame in frames:
                     print('Received frame: ')
                     pp.pprint(frame)

--- a/nixnet_examples/can_signal_single_point_io.py
+++ b/nixnet_examples/can_signal_single_point_io.py
@@ -82,8 +82,7 @@ def main():
                 # They should be the same as the ones sent.
                 time.sleep(1)
 
-                num_signals = len(value_buffer)
-                signals = input_session.signals.read(num_signals)
+                signals = input_session.signals.read()
                 for timestamp, value in signals:
                     date = convert_timestamp(timestamp)
                     print('Received signal with timepstamp %s and value %s' % (date, value))

--- a/nixnet_examples/can_signal_single_point_io.py
+++ b/nixnet_examples/can_signal_single_point_io.py
@@ -28,15 +28,21 @@ def convert_timestamp(timestamp):
 def main():
     database_name = 'NIXNET_example'
     cluster_name = 'CAN_Cluster'
-    input_signal_list = ['CANEventSignal1', 'CANEventSignal2']
-    output_signal_list = ['CANEventSignal1', 'CANEventSignal2']
+    input_signals = ['CANEventSignal1', 'CANEventSignal2']
+    output_signals = ['CANEventSignal1', 'CANEventSignal2']
     interface1 = 'CAN1'
     interface2 = 'CAN2'
-    input_mode = constants.CreateSessionMode.SIGNAL_IN_SINGLE_POINT
-    output_mode = constants.CreateSessionMode.SIGNAL_OUT_SINGLE_POINT
 
-    with nixnet.Session(database_name, cluster_name, input_signal_list, interface1, input_mode) as input_session:
-        with nixnet.Session(database_name, cluster_name, output_signal_list, interface2, output_mode) as output_session:
+    with nixnet.SignalInSinglePointSession(
+            interface1,
+            database_name,
+            cluster_name,
+            input_signals) as input_session:
+        with nixnet.SignalOutSinglePointSession(
+                interface2,
+                database_name,
+                cluster_name,
+                output_signals) as output_session:
             terminated_cable = six.moves.input('Are you using a terminated cable (Y or N)? ')
             if terminated_cable.lower() == "y":
                 input_session.intf.can_term = constants.CanTerm.ON
@@ -53,14 +59,14 @@ def main():
             # signal value sent before the initial read will be received.
             input_session.start()
 
-            user_value = six.moves.input('Enter {} signal values [float, float]: '.format(len(input_signal_list)))
+            user_value = six.moves.input('Enter {} signal values [float, float]: '.format(len(input_signals)))
             try:
                 value_buffer = [float(x.strip()) for x in user_value.split(",")]
             except ValueError:
                 value_buffer = [24.5343, 77.0129]
                 print('Unrecognized input ({}). Setting data buffer to {}', user_value, value_buffer)
 
-            if len(value_buffer) != len(input_signal_list):
+            if len(value_buffer) != len(input_signals):
                 value_buffer = [24.5343, 77.0129]
                 print('Invalid number of signal values entered. Setting data buffer to {}', value_buffer)
 
@@ -69,7 +75,7 @@ def main():
             while True:
                 for index, value in enumerate(value_buffer):
                     value_buffer[index] = value + i
-                output_session.write_signal_single_point(value_buffer)
+                output_session.signals.write(value_buffer)
                 print('Sent signal values: %s' % value_buffer)
 
                 # Wait 1 s and then read the received values.
@@ -77,7 +83,7 @@ def main():
                 time.sleep(1)
 
                 num_signals = len(value_buffer)
-                signals = input_session.read_signal_single_point(num_signals)
+                signals = input_session.signals.read(num_signals)
                 for timestamp, value in signals:
                     date = convert_timestamp(timestamp)
                     print('Received signal with timepstamp %s and value %s' % (date, value))

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -16,6 +16,7 @@ from nixnet_examples import can_signal_single_point_io
 MockXnetLibrary = mock.create_autospec(_cfuncs.XnetLibrary, spec_set=True, instance=True)
 MockXnetLibrary.nx_create_session.return_value = _ctypedefs.u32(0)
 MockXnetLibrary.nx_set_property.return_value = _ctypedefs.u32(0)
+MockXnetLibrary.nx_get_property.return_value = _ctypedefs.u32(0)
 MockXnetLibrary.nx_start.return_value = _ctypedefs.u32(0)
 MockXnetLibrary.nx_write_frame.return_value = _ctypedefs.u32(0)
 MockXnetLibrary.nx_read_frame.return_value = _ctypedefs.u32(0)
@@ -50,7 +51,7 @@ def test_can_frame_stream_empty_session():
 
 
 @mock.patch('nixnet._cfuncs.lib', MockXnetLibrary)
-@mock.patch('six.moves.input', six_input(['y', '1, 2, 3', 'q']))
+@mock.patch('six.moves.input', six_input(['y', '1, 2', 'q']))
 @mock.patch('time.sleep', lambda time: None)
 def test_can_signal_single_point_empty_session():
     can_signal_single_point_io.main()


### PR DESCRIPTION
This is a part of #23 where we are trying to get the API stable-ish.

Benefits
- Guide the user to relevant API functionality rather than burying it in
  docs or waiting until runtime errors
- Tailored `Session.__init__` for the mode, like LabVIEW
- Static design (read/write don't dynamically adapt based on the mode),
  allowing for improved static analysis.

Downsides
- Reads and writes are common operations but buried one level deeper.
  - But similar to DAQmx's `stream` object but more context aware (but
    DAQmx has "simple read/write" flavors)
  - `Session.frames` and `Session.signals` already existed so it can
    logically make sense to put these operation on those objects.
  - The reads/writes would already have "signals" and "frames" in there
    name, so the overall length isn't any longer.
  - Less code duplication because a `Frames` object can be reused across
    modes.

Concerns
- Number of modes this will lead to once we've implemented them all
- There might be properties that do not apply to all modes, especially the
  conversion modes.
- That there might be some more mode-specific semantics we want to expose

### Boilerplate

- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nixnet-python/blob/master/CONTRIBUTING.rst).
- [x] New tests have been created for any new features or regression tests for bugfixes.
- [x] `tox` successfully runs, including unit tests and style checks (see [CONTRIBUTING.md](https://github.com/ni/nixnet-python/blob/master/CONTRIBUTING.rst)).

### What testing has been done?

None
