### PR TITLE
Adding docstrings for SessionBase class, mode specific sesssion classes, frame and signal read and write functions

### DIFF
--- a/nixnet/_session/base.py
+++ b/nixnet/_session/base.py
@@ -1,0 +1,408 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import warnings
+
+from nixnet import _funcs
+from nixnet import _props
+from nixnet import constants
+from nixnet import errors
+
+from nixnet._session import intf
+from nixnet._session import j1939
+
+
+class SessionBase(object):
+    """Session base object."""
+
+    def __init__(
+            self,
+            database_name,
+            cluster_name,
+            list,
+            interface_name,
+            mode):
+        """Create an XNET session at run time using named references to database objects.
+
+        This function creates a session using the named database objects
+        specified in 'list' from the database named in 'database_name'.
+
+        This function is intended to be used by session classes that derive from
+        SessionBase; therefore, it is not public.
+
+        Args:
+            database_name: A string representing the XNET database to use for
+                interface configuration. The database name must use the <alias>
+                or <filepath> syntax (refer to Databases).
+            cluster_name: A string representing the XNET cluster to use for
+                interface configuration. The name must specify a cluster from
+                the database given in the database_name parameter. If it is left
+                blank, the cluster is extracted from the list parameter; this is
+                not allowed for modes of
+                :class:`nixnet.constants.CreateSessionMode.FRAME_IN_STREAM`
+                or :class:`nixnet.constants.CreateSessionMode.FRAME_OUT_STREAM`.
+            list: A list of strings describing signals or frames for the session.
+                The list syntax depends on the mode. Refer to mode spefic
+                session classes defined below for 'list' syntax.
+            interface_name: A string representing the XNET Interface to use for
+                this session. If Mode is
+                :class:`nixnet.constants.CreateSessionMode.SIGNAL_CONVERSION_SINGLE_POINT`,
+                this input is ignored. You can set it to an empty string.
+            mode: The session mode. See :class:`nixnet._enums.CreateSessionMode`.
+
+        Returns:
+            A Session object.
+        """
+        self._handle = None  # To satisfy `__del__` in case nx_create_session throws
+        self._handle = _funcs.nx_create_session(database_name, cluster_name, list, interface_name, mode)
+        self._intf = intf.Interface(self._handle)
+        self._j1939 = j1939.J1939(self._handle)
+
+    def __del__(self):
+        if self._handle is not None:
+            warnings.warn(
+                'Session was not explicitly closed before it was destructed. '
+                'Resources on the device may still be reserved.',
+                errors.XnetResourceWarning)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, type, value, traceback):
+        self.close()
+
+    def __eq__(self, other):
+        if isinstance(other, self.__class__):
+            return self._handle == other._handle
+        return False
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
+
+    def __hash__(self):
+        return hash(self._handle)
+
+    def __repr__(self):
+        return 'Session(handle={0})'.format(self._handle)
+
+    def close(self):
+        """Close (clear) the XNET session.
+
+        This function stops communication for the session and releases all
+        resources the session uses. It internally calls
+        :class:`nixnet.session.Session.stop` with normal scope, so if this is the
+        last session using the interface, communication stops.
+
+        You typically use 'close' when you need to close the existing session to
+        create a new session that uses the same objects. For example, if you
+        create a session for a frame named frame_a using Frame Output
+        Single-Point mode, then you create a second session for frame_a using
+        Frame Output Queued mode, the second call to the session constructor
+        returns an error, because frame_a can be accessed using only one output
+        mode. If you call 'close' before the second constructor call, you can
+        close the previous use of frame_a to create the new session.
+
+        Args:
+            None
+
+        Returns:
+            None
+        """
+        if self._handle is None:
+            warnings.warn(
+                'Attempting to close NI-XNET session but session was already '
+                'closed', errors.XnetResourceWarning)
+            return
+
+        _funcs.nx_clear(self._handle)
+
+        self._handle = None
+
+    def start(self, scope=constants.StartStopScope.NORMAL):
+        """Start communication for the XNET session.
+
+        Because the session is started automatically by default, this function
+        is optional. This function is for more advanced applications to start
+        multiple sessions in a specific order. For more information about the
+        automatic start feature, refer to the
+        :class:`nixnet.session.Session.auto_start` property.
+
+        For each physical interface, the NI-XNET hardware is divided into two logical units:
+            Sessions: You can create one or more sessions, each of which contains
+                frames or signals to be transmitted (or received) on the bus.
+            Interface: The interface physically connects to the bus and transmits
+                (or receives) data for the sessions.
+
+        You can start each logical unit separately. When a session is started,
+        all contained frames or signals are placed in a state where they are
+        ready to communicate. When the interface is started, it takes data from
+        all started sessions to communicate with other nodes on the bus. For a
+        specification of the state models for the session and interface, refer
+        to State Models.
+
+        If an output session starts before you write data, or you read an input
+        session before it receives a frame, default data is used. For more
+        information, refer to the XNET Frame Default Payload and XNET Signal
+        Default Value properties.
+
+        Args:
+            scope: Describes the impact of this operation on the underlying
+                state models for the session and its interface.
+                See :class:`nixnet._enums.StartStopScope`.
+
+        Returns:
+            None
+        """
+        _funcs.nx_start(self._handle, scope)
+
+    def stop(self, scope=constants.StartStopScope.NORMAL):
+        """Stop communication for the XNET session.
+
+        Because the session is stopped automatically when closed (cleared),
+        this function is optional.
+
+        For each physical interface, the NI-XNET hardware is divided into two logical units:
+            Sessions: You can create one or more sessions, each of which contains
+                frames or signals to be transmitted (or received) on the bus.
+            Interface: The interface physically connects to the bus and transmits
+                (or receives) data for the sessions.
+
+        You can stop each logical unit separately. When a session is stopped,
+        all contained frames or signals are placed in a state where they are no
+        longer ready to communicate. When the interface is stopped, it no longer
+        takes data from sessions to communicate with other nodes on the bus. For
+        a specification of the state models for the session and interface, refer
+        to State Models.
+
+        Args:
+            scope: Describes the impact of this operation on the underlying
+                state models for the session and its interface.
+                See :class:`nixnet._enums.StartStopScope`.
+
+        Returns:
+            None
+        """
+        _funcs.nx_stop(self._handle, scope)
+
+    def flush(self):
+        """Flushes (empties) all XNET session queues.
+
+        With the exception of single-point modes, all sessions use queues to
+        store frames. For input modes, the queues store frame values (or
+        corresponding signal values) that have been received, but not obtained
+        by calling the read function. For output sessions, the queues store
+        frame values provided to write function, but not transmitted successfully.
+
+        :class:`nixnet.session.Session.start` and :class:`nixnet.session.Session.stop`
+        have no effect on these queues. Use 'flush' to discard all values in the
+        session's queues.
+
+        For example, if you call a write function to write three frames, then
+        immediately call :class:`nixnet.session.Session.stop`, then call
+        :class:`nixnet.session.Session.start` a few seconds later, the three frames
+        transmit. If you call 'flush' between :class:`nixnet.session.Session.stop` and
+        :class:`nixnet.session.Session.start`, no frames transmit.
+
+        As another example, if you receive three frames, then call
+        :class:`nixnet.session.Session.stop`, the three frames remains in the queue.
+        If you call :class:`nixnet.session.Session.start` a few seconds later, then
+        call a read function, you obtain the three frames received earlier,
+        potentially followed by other frames received after calling
+        :class:`nixnet.session.Session.start`. If you call 'flush' between
+        :class:`nixnet.session.Session.stop` and :class:`nixnet.session.Session.start`,
+        read function returns only frames received after the calling
+        :class:`nixnet.session.Session.start`.
+
+        Args:
+            None
+
+        Returns:
+            None
+        """
+        _funcs.nx_flush(self._handle)
+
+    def wait_for_transmit_complete(self, timeout=10):
+        """Wait for transmition to complete.
+
+        All frames written for the session have been transmitted on the bus.
+        This condition applies to CAN, LIN, and FlexRay. This condition is state
+        based, and the state is Boolean (true/false).
+
+        Args:
+            timeout: A float representing the maximum amount of time to wait in
+                seconds.
+
+        Returns:
+            None
+        """
+        _funcs.nx_wait(self._handle, constants.Condition.TRANSMIT_COMPLETE, 0, timeout)
+
+    def wait_for_intf_communicating(self, timeout=10):
+        """Wait for the interface to begin communication on the network.
+
+        If a start trigger is configured for the interface, this first waits for
+        the trigger. Once the interface is started, this waits for the
+        protocol's communication state to transition to a value that indicates
+        communication with remote nodes.
+
+        After this wait succeeds, calls to 'read_state' will return:
+            :class:`nixnet.constants.ReadState.CAN_COMM`:
+                :class:`nixnet.constants.ReadState.CAN_COMM.ERROR_ACTIVE`
+            :class:`nixnet.constants.ReadState.CAN_COMM`:
+                :class:`nixnet.constants.ReadState.CAN_COMM.ERROR_PASSIVE`
+            :class:`nixnet.constants.ReadState.TIME_COMMUNICATING`: Valid time
+                for communication (invalid time of 0 prior)
+
+        Args:
+            timeout: A float representing the maximum amount of time to wait in
+                seconds.
+
+        Returns:
+            None
+        """
+        _funcs.nx_wait(self._handle, constants.Condition.INTF_COMMUNICATING, 0, timeout)
+
+    def wait_for_intf_remote_wakeup(self, timeout=10):
+        """Wait for interface remote wakeup.
+
+        Wait for the interface to wakeup due to activity by a remote node on the
+        network. This wait is used for CAN, when you set the 'can_tcvr_state'
+        property to :class:`nixnet.constants.CanTcvrState.SLEEP`. Although the
+        interface itself is ready to communicate, this places the transceiver
+        into a sleep state. When a remote CAN node transmits a frame, the
+        transceiver wakes up, and communication is restored. This wait detects
+        that remote wakeup.
+
+        This wait is used for LIN when you set 'lin_sleep' property to
+        :class:`nixnet.constants.LinSleep.REMOTE_SLEEP` or
+        :class:`nixnet.constants.LinSleep.LOCAL_SLEEP`. When asleep, if a remote
+        LIN ECU transmits the wakeup pattern (break), the XNET LIN interface
+        detects this transmission and wakes up. This wait detects that remote wakeup.
+
+        Args:
+            timeout: A float representing the maximum amount of time to wait in
+                seconds.
+
+        Returns:
+            None
+        """
+        _funcs.nx_wait(self._handle, constants.Condition.INTF_REMOTE_WAKEUP, 0, timeout)
+
+    def connect_terminals(self, source, destination):
+        """Connect terminals on the XNET interface.
+
+        This function connects a source terminal to a destination terminal on
+        the interface hardware. The XNET terminal represents an external or
+        internal hardware connection point on a National Instruments XNET
+        hardware product. External terminals include PXI Trigger lines for a PXI
+        card, RTSI terminals for a PCI card, or the single external terminal for
+        a C Series module. Internal terminals include timebases (clocks) and
+        logical entities such as a start trigger.
+
+        The terminal inputs use the Terminal I/O names. Typically, one of the
+        pair is an internal and the other an external.
+
+        Args:
+            source: A string representing the connection source name.
+            destination: A string representing the connection destination name.
+
+        Returns:
+            None
+        """
+        _funcs.nx_connect_terminals(self._handle, source, destination)
+
+    def disconnect_terminals(self, source, destination):
+        """Disconnect terminals on the XNET interface.
+
+        This function disconnects a specific pair of source/destination terminals
+        previously connected with :class:`nixnet.session.Session.connect_terminals`.
+
+        When the final session for a given interface is cleared, NI-XNET
+        automatically disconnects all terminal connections for that interface.
+        Therefore, 'disconnect_terminals' is not required for most applications.
+
+        This function typically is used to change terminal connections
+        dynamically while an application is running. To disconnect a terminal,
+        you first must stop the interface using :class:`nixnet.session.Session.stop`
+        with the Interface Only scope. Then you can call 'disconnect_terminals'
+        and :class:`nixnet.session.Session.connect_terminals` to adjust terminal
+        connections. Finally, you can call :class:`nixnet.session.Session.start` with
+        the Interface Only scope to restart the interface.
+
+        You can disconnect only a terminal that has been previously connected.
+        Attempting to disconnect a nonconnected terminal results in an error.
+
+        Args:
+            source: A string representing the connection source name.
+            destination: A string representing the connection destination name.
+
+        Returns:
+            None
+        """
+        _funcs.nx_disconnect_terminals(self._handle, source, destination)
+
+    @property
+    def intf(self):
+        return self._intf
+
+    @property
+    def j1939(self):
+        return self._j1939
+
+    @property
+    def application_protocol(self):
+        return constants.AppProtocol(_props.get_session_application_protocol(self._handle))
+
+    @property
+    def auto_start(self):
+        return _props.get_session_auto_start(self._handle)
+
+    @auto_start.setter
+    def auto_start(self, value):
+        _props.set_session_auto_start(self._handle, value)
+
+    @property
+    def cluster_name(self):
+        return _props.get_session_cluster_name(self._handle)
+
+    @property
+    def database_name(self):
+        return _props.get_session_database_name(self._handle)
+
+    @property
+    def mode(self):
+        return constants.CreateSessionMode(_props.get_session_mode(self._handle))
+
+    @property
+    def num_pend(self):
+        return _props.get_session_num_pend(self._handle)
+
+    @property
+    def num_unused(self):
+        return _props.get_session_num_unused(self._handle)
+
+    @property
+    def payld_len_max(self):
+        return _props.get_session_payld_len_max(self._handle)
+
+    @property
+    def protocol(self):
+        return constants.Protocol(_props.get_session_protocol(self._handle))
+
+    @property
+    def queue_size(self):
+        return _props.get_session_queue_size(self._handle)
+
+    @queue_size.setter
+    def queue_size(self, value):
+        _props.set_session_queue_size(self._handle, value)
+
+    @property
+    def resamp_rate(self):
+        return _props.get_session_resamp_rate(self._handle)
+
+    @resamp_rate.setter
+    def resamp_rate(self, value):
+        _props.set_session_resamp_rate(self._handle, value)

--- a/nixnet/_session/frames.py
+++ b/nixnet/_session/frames.py
@@ -30,14 +30,43 @@ class InFrames(Frames):
             self,
             number_of_bytes_to_read,
             timeout=constants.TIMEOUT_NONE):
-        """Read frames.
+        """Read data as a list of raw bytes (frame data).
 
-        Valid modes
-        - Frame Input Stream Mode
-        - Frame Input Queued Mode
-        - Frame Input Single-Point Mode
-        Frame: one or more
-        http://zone.ni.com/reference/en-XX/help/372841N-01/nixnet/nxreadframe/
+        The raw bytes encode one or more frames using the Raw Frame Format.
+
+        Args:
+            number_of_bytes_to_read: An integer repesenting the number of bytes to read.
+            timeout: The time to wait for number to read frame bytes to become
+                available; the 'timeout' is represented as 64-bit floating-point
+                in units of seconds.
+
+                To avoid returning a partial frame, even when
+                'number_of_bytes_to_read' are available from the hardware, this
+                read may return fewer bytes in buffer. For example, assume you
+                pass 'number_of_bytes_to_read' 70 bytes and 'timeout' of 10
+                seconds. During the read, two frames are received, the first 24
+                bytes in size, and the second 56 bytes in size, for a total of
+                80 bytes. The read returns after the two frames are received,
+                but only the first frame is copied to data. If the read copied
+                46 bytes of the second frame (up to the limit of 70), that frame
+                would be incomplete and therefore difficult to interpret. To
+                avoid this problem, the read always returns complete frames in
+                buffer.
+
+                If 'timeout' is positive, this function waits for
+                'number_of_bytes_to_read' frame bytes to be received, then
+                returns complete frames up to that number. If the bytes do not
+                arrive prior to the 'timeout', an error is returned.
+
+                If 'timeout' is negative, this function waits indefinitely for
+                'number_of_bytes_to_read' frame bytes.
+
+                If 'timeout' is zero, this function does not wait and immediately
+                returns all available frame bytes up to the limit
+                'number_of_bytes_to_read' specifies.
+
+        Returns:
+            A list of raw bytes representing the data.
         """
         buffer, number_of_bytes_returned = _funcs.nx_read_frame(self._handle, number_of_bytes_to_read, timeout)
         return buffer[0:number_of_bytes_returned]
@@ -46,14 +75,17 @@ class InFrames(Frames):
             self,
             number_to_read,
             timeout=constants.TIMEOUT_NONE):
-        """Read frames.
+        """Read raw CAN frames.
 
-        Valid modes
-        - Frame Input Stream Mode
-        - Frame Input Queued Mode
-        - Frame Input Single-Point Mode
-        Frame: one or more
-        http://zone.ni.com/reference/en-XX/help/372841N-01/nixnet/nxreadframe/
+        Args:
+            number_to_read: An integer repesenting the number of raw CAN frames
+                to read.
+            timeout: The time to wait for number to read frames to become
+                available; the 'timeout' is represented as 64-bit floating-point
+                in units of seconds.
+
+        Yields:
+            :class:`nixnet.types.RawFrame`
         """
         # NOTE: If the frame payload excedes the base unit, this will return
         # less than number_to_read
@@ -66,14 +98,16 @@ class InFrames(Frames):
             self,
             number_to_read,
             timeout=constants.TIMEOUT_NONE):
-        """Read frames.
+        """Read :class:`nixnet.types.CanFrame` data.
 
-        Valid modes
-        - Frame Input Stream Mode
-        - Frame Input Queued Mode
-        - Frame Input Single-Point Mode
-        Frame: one or more
-        http://zone.ni.com/reference/en-XX/help/372841N-01/nixnet/nxreadframe/
+        Args:
+            number_to_read: An integer repesenting the number of CAN frames to read.
+            timeout: The time to wait for number to read frames to become
+                available; the 'timeout' is represented as 64-bit floating-point
+                in units of seconds.
+
+        Yields:
+            :class:`nixnet.types.CanFrame`
         """
         for frame in self.read_raw(number_to_read, timeout):
             yield types.CanFrame.from_raw(frame)
@@ -88,14 +122,13 @@ class SinglePointInFrames(Frames):
     def read_bytes(
             self,
             number_of_bytes_to_read):
-        """Read frames.
+        """Read data as a list of raw bytes (frame data).
 
-        Valid modes
-        - Frame Input Stream Mode
-        - Frame Input Queued Mode
-        - Frame Input Single-Point Mode
-        Frame: one or more
-        http://zone.ni.com/reference/en-XX/help/372841N-01/nixnet/nxreadframe/
+        Args:
+            number_of_bytes_to_read: An integer repesenting the number of bytes to read.
+
+        Returns:
+            A list of raw bytes representing the data.
         """
         buffer, number_of_bytes_returned = _funcs.nx_read_frame(
             self._handle,
@@ -104,14 +137,13 @@ class SinglePointInFrames(Frames):
         return buffer[0:number_of_bytes_returned]
 
     def read_raw(self):
-        """Read frames.
+        """Read raw CAN frames.
 
-        Valid modes
-        - Frame Input Stream Mode
-        - Frame Input Queued Mode
-        - Frame Input Single-Point Mode
-        Frame: one or more
-        http://zone.ni.com/reference/en-XX/help/372841N-01/nixnet/nxreadframe/
+        Args:
+            None
+
+        Yields:
+            :class:`nixnet.types.RawFrame`
         """
         # NOTE: If the frame payload exceeds the base unit, this will return
         # less than number_to_read
@@ -122,14 +154,13 @@ class SinglePointInFrames(Frames):
             yield frame
 
     def read_can(self):
-        """Read frames.
+        """Read :class:`nixnet.types.CanFrame` data.
 
-        Valid modes
-        - Frame Input Stream Mode
-        - Frame Input Queued Mode
-        - Frame Input Single-Point Mode
-        Frame: one or more
-        http://zone.ni.com/reference/en-XX/help/372841N-01/nixnet/nxreadframe/
+        Args:
+            None
+
+        Yields:
+            :class:`nixnet.types.CanFrame`
         """
         for frame in self.read_raw():
             yield types.CanFrame.from_raw(frame)
@@ -145,14 +176,61 @@ class OutFrames(Frames):
             self,
             frame_bytes,
             timeout=10):
-        "http://zone.ni.com/reference/en-XX/help/372841N-01/nixnet/nxwriteframe/"
+        """Write a list of raw bytes (frame data).
+
+        The raw bytes encode one or more frames using the Raw Frame Format.
+
+        Args:
+            frame_bytes: List of bytes, representing frames to transmit.
+            timeout: The time to wait for the data to be queued up for transmit.
+                The 'timeout' is represented as 64-bit floating-point in units of seconds.
+
+                If 'timeout' is positive, this function waits up to that 'timeout'
+                for space to become available in queues. If the space is not
+                available prior to the 'timeout', a 'timeout' error is returned.
+
+                If 'timeout' is negative, this functions waits indefinitely for
+                space to become available in queues.
+
+                If 'timeout' is 0, this function does not wait and immediately
+                returns with a 'timeout' error if all data cannot be queued.
+                Regardless of the 'timeout' used, if a 'timeout' error occurs,
+                none of the data is queued, so you can attempt to call this
+                function again at a later time with the same data.
+
+        Returns:
+            None
+        """
         _funcs.nx_write_frame(self._handle, bytes(frame_bytes), timeout)
 
     def write_raw(
             self,
             raw_frames,
             timeout=10):
-        "http://zone.ni.com/reference/en-XX/help/372841N-01/nixnet/nxwriteframe/"
+        """Write raw CAN frame data.
+
+        Args:
+            raw_frames: One or more :class:`nixnet.types.RawFrame` objects to be
+                written to the session.
+            timeout: The time to wait for the data to be queued up for transmit.
+                The 'timeout' is represented as 64-bit floating-point in units of seconds.
+
+                If 'timeout' is positive, this function waits up to that 'timeout'
+                for space to become available in queues. If the space is not
+                available prior to the 'timeout', a 'timeout' error is returned.
+
+                If 'timeout' is negative, this functions waits indefinitely for
+                space to become available in queues.
+
+                If 'timeout' is 0, this function does not wait and immediately
+                returns with a 'timeout' error if all data cannot be queued.
+                Regardless of the 'timeout' used, if a 'timeout' error occurs,
+                none of the data is queued, so you can attempt to call this
+                function again at a later time with the same data.
+
+        Returns:
+            None
+        """
         units = itertools.chain.from_iterable(
             _frames.serialize_frame(frame)
             for frame in raw_frames)
@@ -163,7 +241,30 @@ class OutFrames(Frames):
             self,
             can_frames,
             timeout=10):
-        "http://zone.ni.com/reference/en-XX/help/372841N-01/nixnet/nxwriteframe/"
+        """Write CAN frame data.
+
+        Args:
+            can_frames: One or more :class:`nixnet.types.CanFrame` objects to be
+                written to the session.
+            timeout: The time to wait for the data to be queued up for transmit.
+                The 'timeout' is represented as 64-bit floating-point in units of seconds.
+
+                If 'timeout' is positive, this function waits up to that 'timeout'
+                for space to become available in queues. If the space is not
+                available prior to the 'timeout', a 'timeout' error is returned.
+
+                If 'timeout' is negative, this functions waits indefinitely for
+                space to become available in queues.
+
+                If 'timeout' is 0, this function does not wait and immediately
+                returns with a 'timeout' error if all data cannot be queued.
+                Regardless of the 'timeout' used, if a 'timeout' error occurs,
+                none of the data is queued, so you can attempt to call this
+                function again at a later time with the same data.
+
+        Returns:
+            None
+        """
         raw_frames = (frame.to_raw() for frame in can_frames)
         self.write_raw(raw_frames, timeout)
 
@@ -177,13 +278,30 @@ class SinglePointOutFrames(Frames):
     def write_bytes(
             self,
             frame_bytes):
-        "http://zone.ni.com/reference/en-XX/help/372841N-01/nixnet/nxwriteframe/"
+        """Write a list of raw bytes (frame data).
+
+        The raw bytes encode one or more frames using the Raw Frame Format.
+
+        Args:
+            frame_bytes: List of bytes, representing frames to transmit.
+
+        Returns:
+            None
+        """
         _funcs.nx_write_frame(self._handle, bytes(frame_bytes), constants.TIMEOUT_NONE)
 
     def write_raw(
             self,
             raw_frames):
-        "http://zone.ni.com/reference/en-XX/help/372841N-01/nixnet/nxwriteframe/"
+        """Write raw CAN frame data.
+
+        Args:
+            raw_frames: One or more :class:`nixnet.types.RawFrame` objects to be
+                written to the session.
+
+        Returns:
+            None
+        """
         units = itertools.chain.from_iterable(
             _frames.serialize_frame(frame)
             for frame in raw_frames)
@@ -193,7 +311,15 @@ class SinglePointOutFrames(Frames):
     def write_can(
             self,
             can_frames):
-        "http://zone.ni.com/reference/en-XX/help/372841N-01/nixnet/nxwriteframe/"
+        """Write CAN frame data.
+
+        Args:
+            can_frames: One or more :class:`nixnet.types.CanFrame` objects to be
+                written to the session.
+
+        Returns:
+            None
+        """
         raw_frames = (frame.to_raw() for frame in can_frames)
         self.write_raw(raw_frames)
 

--- a/nixnet/_session/frames.py
+++ b/nixnet/_session/frames.py
@@ -58,12 +58,12 @@ class InFrames(Frames):
                 returns complete frames up to that number. If the bytes do not
                 arrive prior to the 'timeout', an error is returned.
 
-                If 'timeout' is negative, this function waits indefinitely for
-                'number_of_bytes_to_read' frame bytes.
+                If 'timeout' is :class:`nixnet.constants.TIMEOUT_INFINITE`, this
+                function waits indefinitely for 'number_of_bytes_to_read' frame bytes.
 
-                If 'timeout' is zero, this function does not wait and immediately
-                returns all available frame bytes up to the limit
-                'number_of_bytes_to_read' specifies.
+                If 'timeout' is :class:`nixnet.constants.TIMEOUT_NONE`, this
+                function does not wait and immediately returns all available
+                frame bytes up to the limit 'number_of_bytes_to_read' specifies.
 
         Returns:
             A list of raw bytes representing the data.
@@ -83,6 +83,18 @@ class InFrames(Frames):
             timeout: The time to wait for number to read frames to become
                 available; the 'timeout' is represented as 64-bit floating-point
                 in units of seconds.
+
+                If 'timeout' is positive, this function waits for
+                'number_to_read' frames to be received, then
+                returns complete frames up to that number. If the frames do not
+                arrive prior to the 'timeout', an error is returned.
+
+                If 'timeout' is :class:`nixnet.constants.TIMEOUT_INFINITE`, this
+                function waits indefinitely for 'number_to_read' frames.
+
+                If 'timeout' is :class:`nixnet.constants.TIMEOUT_NONE`, this
+                function does not wait and immediately returns all available
+                frames up to the limit 'number_to_read' specifies.
 
         Yields:
             :class:`nixnet.types.RawFrame`
@@ -106,6 +118,17 @@ class InFrames(Frames):
                 available; the 'timeout' is represented as 64-bit floating-point
                 in units of seconds.
 
+                If 'timeout' is positive, this function waits for
+                'number_to_read' frames to be received, then
+                returns complete frames up to that number. If the frames do not
+                arrive prior to the 'timeout', an error is returned.
+
+                If 'timeout' is :class:`nixnet.constants.TIMEOUT_INFINITE`, this
+                function waits indefinitely for 'number_to_read' frames.
+
+                If 'timeout' is :class:`nixnet.constants.TIMEOUT_NONE`, this
+                function does not wait and immediately returns all available
+                frames up to the limit 'number_to_read' specifies.
         Yields:
             :class:`nixnet.types.CanFrame`
         """
@@ -189,14 +212,15 @@ class OutFrames(Frames):
                 for space to become available in queues. If the space is not
                 available prior to the 'timeout', a 'timeout' error is returned.
 
-                If 'timeout' is negative, this functions waits indefinitely for
-                space to become available in queues.
+                If 'timeout' is :class:`nixnet.constants.TIMEOUT_INFINITE`, this
+                functions waits indefinitely for space to become available in queues.
 
-                If 'timeout' is 0, this function does not wait and immediately
-                returns with a 'timeout' error if all data cannot be queued.
-                Regardless of the 'timeout' used, if a 'timeout' error occurs,
-                none of the data is queued, so you can attempt to call this
-                function again at a later time with the same data.
+                If 'timeout' is :class:`nixnet.constants.TIMEOUT_NONE`, this
+                function does not wait and immediately returns with a 'timeout'
+                error if all data cannot be queued. Regardless of the 'timeout'
+                used, if a 'timeout' error occurs, none of the data is queued,
+                so you can attempt to call this function again at a later time
+                with the same data.
 
         Returns:
             None
@@ -219,14 +243,15 @@ class OutFrames(Frames):
                 for space to become available in queues. If the space is not
                 available prior to the 'timeout', a 'timeout' error is returned.
 
-                If 'timeout' is negative, this functions waits indefinitely for
-                space to become available in queues.
+                If 'timeout' is :class:`nixnet.constants.TIMEOUT_INFINITE`, this
+                functions waits indefinitely for space to become available in queues.
 
-                If 'timeout' is 0, this function does not wait and immediately
-                returns with a 'timeout' error if all data cannot be queued.
-                Regardless of the 'timeout' used, if a 'timeout' error occurs,
-                none of the data is queued, so you can attempt to call this
-                function again at a later time with the same data.
+                If 'timeout' is :class:`nixnet.constants.TIMEOUT_NONE`, this
+                function does not wait and immediately returns with a 'timeout'
+                error if all data cannot be queued. Regardless of the 'timeout'
+                used, if a 'timeout' error occurs, none of the data is queued,
+                so you can attempt to call this function again at a later time
+                with the same data.
 
         Returns:
             None
@@ -253,14 +278,15 @@ class OutFrames(Frames):
                 for space to become available in queues. If the space is not
                 available prior to the 'timeout', a 'timeout' error is returned.
 
-                If 'timeout' is negative, this functions waits indefinitely for
-                space to become available in queues.
+                If 'timeout' is :class:`nixnet.constants.TIMEOUT_INFINITE`, this
+                functions waits indefinitely for space to become available in queues.
 
-                If 'timeout' is 0, this function does not wait and immediately
-                returns with a 'timeout' error if all data cannot be queued.
-                Regardless of the 'timeout' used, if a 'timeout' error occurs,
-                none of the data is queued, so you can attempt to call this
-                function again at a later time with the same data.
+                If 'timeout' is :class:`nixnet.constants.TIMEOUT_NONE`, this
+                function does not wait and immediately returns with a 'timeout'
+                error if all data cannot be queued. Regardless of the 'timeout'
+                used, if a 'timeout' error occurs, none of the data is queued,
+                so you can attempt to call this function again at a later time
+                with the same data.
 
         Returns:
             None
@@ -296,7 +322,7 @@ class SinglePointOutFrames(Frames):
         """Write raw CAN frame data.
 
         Args:
-            raw_frames: One or more :class:`nixnet.types.RawFrame` objects to be
+            raw_frames: A list of :class:`nixnet.types.RawFrame` objects to be
                 written to the session.
 
         Returns:
@@ -314,7 +340,7 @@ class SinglePointOutFrames(Frames):
         """Write CAN frame data.
 
         Args:
-            can_frames: One or more :class:`nixnet.types.CanFrame` objects to be
+            can_frames: A list of :class:`nixnet.types.CanFrame` objects to be
                 written to the session.
 
         Returns:

--- a/nixnet/_session/signals.py
+++ b/nixnet/_session/signals.py
@@ -22,14 +22,13 @@ class SinglePointInSignals(Signals):
         return 'Session.SinglePointInSignals(handle={0})'.format(self._handle)
 
     def read(self):
-        """Read signal single point.
+        """Read data from a Signal Input Single-Point session.
 
-        Valid modes
-        - Single Input Single-Point
-        Timestamps
-        - Optional in C API
-        - Timestamp per data point
-        http://zone.ni.com/reference/en-XX/help/372841N-01/nixnet/nxreadsignalsinglepoint/
+        Args:
+            None
+
+        Yields:
+            A tuple of timestamp (class:`nixnet._ctypedefs.nxTimestamp_t`) and signal values (float).
         """
         num_signals = len(self)
         timestamps, values = _funcs.nx_read_signal_single_point(self._handle, num_signals)
@@ -46,7 +45,14 @@ class SinglePointOutSignals(Signals):
     def write(
             self,
             value_buffer):
-        "http://zone.ni.com/reference/en-XX/help/372841N-01/nixnet/nxwritesignalsinglepoint/"
+        """Write data to a Signal Output Single-Point session.
+
+        Args:
+            value_buffer: A list of singal values (float).
+
+        Returns:
+            None
+        """
         _funcs.nx_write_signal_single_point(self._handle, value_buffer)
 
 

--- a/nixnet/session.py
+++ b/nixnet/session.py
@@ -27,6 +27,31 @@ __all__ = [
 
 
 class SessionBase(object):
+    """Session base object.
+
+    The NI-XNET session represents a connection between your National Instruments
+    CAN/FlexRay/LIN hardware and hardware products on the external network.
+
+    In addition to read/write of I/O data, you can use the session to interact
+    with the network in other ways. For example, 'read_state' includes
+    selections to read the state of communication, such as whether communication
+    has stopped due to error detection defined by the protocol standard.
+
+    You can use sessions for multiple hardware interfaces. For each interface,
+    you can use multiple input sessions and multiple output sessions
+    simultaneously. The sessions can use different modes. For example, you can
+    use a Signal Input Single-Point session at the same time you use a Frame
+    Input Stream session.
+
+    The limitations on sessions relate primarily to a specific frame or its
+    signals. For example, if you create a
+    class:`nixnet.session.FrameOutQueuedSession` session for frame_a, then create
+    a class:`nixnet.session.SignalOutSinglePointSession` session for
+    frame_a.signal_b (a signal in frame_a), NI-XNET returns an error. This
+    combination of sessions is not allowed, because writing data for the same
+    frame with two sessions would result in inconsistent sequences of data on
+    the network.
+    """
 
     def __init__(
             self,
@@ -35,7 +60,32 @@ class SessionBase(object):
             list,
             interface,
             mode):
-        "http://zone.ni.com/reference/en-XX/help/372841N-01/nixnet/nxcreatesession/"
+        """Create an XNET session at run time using named references to database objects.
+
+        This function creates a session using the named database objects
+        specified in 'list' from the database named in 'database_name'.
+
+        Args:
+            database_name: The XNET database to use for interface configuration.
+                The database name must use the <alias> or <filepath> syntax
+                (refer to Databases).
+            cluster_name: The XNET cluster to use for interface configuration.
+                The name must specify a cluster from the database given in the
+                database_name parameter. If it is left blank, the cluster is
+                extracted from the list parameter; this is not allowed for modes
+                of :class:`nixnet.constants.CreateSessionMode.FRAME_IN_STREAM`
+                or :class:`nixnet.constants.CreateSessionMode.FRAME_OUT_STREAM`.
+            list: A list of strings describing signals or frames for the session.
+                The list syntax depends on the mode. Refer to mode spefic
+                session classes defined below for 'list' syntax.
+            interface: The XNET Interface to use for this session. If Mode is
+                :class:`nixnet.constants.CreateSessionMode.SIGNAL_CONVERSION_SINGLE_POINT`,
+                this input is ignored. You can set it to an empty string.
+            mode: The session mode. See :class:`nixnet._enums.CreateSessionMode`.
+
+        Returns:
+            A Session object.
+        """
         self._handle = None  # To satisfy `__del__` in case nx_create_session throws
         self._handle = _funcs.nx_create_session(database_name, cluster_name, list, interface, mode)
         self._intf = intf.Interface(self._handle)
@@ -69,7 +119,28 @@ class SessionBase(object):
         return 'Session(handle={0})'.format(self._handle)
 
     def close(self):
-        "http://zone.ni.com/reference/en-XX/help/372841N-01/nixnet/nxclear/"
+        """Close (clear) the XNET session.
+
+        This function stops communication for the session and releases all
+        resources the session uses. It internally calls
+        :class:`nixnet.session.Session.stop` with normal scope, so if this is the
+        last session using the interface, communication stops.
+
+        You typically use 'close' when you need to close the existing session to
+        create a new session that uses the same objects. For example, if you
+        create a session for a frame named frame_a using Frame Output
+        Single-Point mode, then you create a second session for frame_a using
+        Frame Output Queued mode, the second call to the session constructor
+        returns an error, because frame_a can be accessed using only one output
+        mode. If you call 'close' before the second constructor call, you can
+        close the previous use of frame_a to create the new session.
+
+        Args:
+            None
+
+        Returns:
+            None
+        """
         if self._handle is None:
             warnings.warn(
                 'Attempting to close NI-XNET session but session was already '
@@ -81,28 +152,223 @@ class SessionBase(object):
         self._handle = None
 
     def start(self, scope=constants.StartStopScope.NORMAL):
-        "http://zone.ni.com/reference/en-XX/help/372841N-01/nixnet/nxstart/"
+        """Start communication for the XNET session.
+
+        Because the session is started automatically by default, this function
+        is optional. This function is for more advanced applications to start
+        multiple sessions in a specific order. For more information about the
+        automatic start feature, refer to the
+        :class:`nixnet.session.Session.auto_start` property.
+
+        For each physical interface, the NI-XNET hardware is divided into two logical units:
+            Sessions: You can create one or more sessions, each of which contains
+                frames or signals to be transmitted (or received) on the bus.
+            Interface: The interface physically connects to the bus and transmits
+                (or receives) data for the sessions.
+
+        You can start each logical unit separately. When a session is started,
+        all contained frames or signals are placed in a state where they are
+        ready to communicate. When the interface is started, it takes data from
+        all started sessions to communicate with other nodes on the bus. For a
+        specification of the state models for the session and interface, refer
+        to State Models.
+
+        If an output session starts before you write data, or you read an input
+        session before it receives a frame, default data is used. For more
+        information, refer to the XNET Frame Default Payload and XNET Signal
+        Default Value properties.
+
+        Args:
+            scope: Describes the impact of this operation on the underlying
+                state models for the session and its interface.
+                See :class:`nixnet._enums.StartStopScope`.
+
+        Returns:
+            None
+        """
         _funcs.nx_start(self._handle, scope)
 
     def stop(self, scope=constants.StartStopScope.NORMAL):
+        """Stop communication for the XNET session.
+
+        Because the session is stopped automatically when closed (cleared),
+        this function is optional.
+
+        For each physical interface, the NI-XNET hardware is divided into two logical units:
+            Sessions: You can create one or more sessions, each of which contains
+                frames or signals to be transmitted (or received) on the bus.
+            Interface: The interface physically connects to the bus and transmits
+                (or receives) data for the sessions.
+
+        You can stop each logical unit separately. When a session is stopped,
+        all contained frames or signals are placed in a state where they are no
+        longer ready to communicate. When the interface is stopped, it no longer
+        takes data from sessions to communicate with other nodes on the bus. For
+        a specification of the state models for the session and interface, refer
+        to State Models.
+
+        Args:
+            scope: Describes the impact of this operation on the underlying
+                state models for the session and its interface.
+                See :class:`nixnet._enums.StartStopScope`.
+
+        Returns:
+            None
+        """
         _funcs.nx_stop(self._handle, scope)
 
     def flush(self):
+        """Flushes (empties) all XNET session queues.
+
+        With the exception of single-point modes, all sessions use queues to
+        store frames. For input modes, the queues store frame values (or
+        corresponding signal values) that have been received, but not obtained
+        by calling the read function. For output sessions, the queues store
+        frame values provided to write function, but not transmitted successfully.
+
+        :class:`nixnet.session.Session.start` and :class:`nixnet.session.Session.stop`
+        have no effect on these queues. Use 'flush' to discard all values in the
+        session's queues.
+
+        For example, if you call a write function to write three frames, then
+        immediately call :class:`nixnet.session.Session.stop`, then call
+        :class:`nixnet.session.Session.start` a few seconds later, the three frames
+        transmit. If you call 'flush' between :class:`nixnet.session.Session.stop` and
+        :class:`nixnet.session.Session.start`, no frames transmit.
+
+        As another example, if you receive three frames, then call
+        :class:`nixnet.session.Session.stop`, the three frames remains in the queue.
+        If you call :class:`nixnet.session.Session.start` a few seconds later, then
+        call a read function, you obtain the three frames received earlier,
+        potentially followed by other frames received after calling
+        :class:`nixnet.session.Session.start`. If you call 'flush' between
+        :class:`nixnet.session.Session.stop` and :class:`nixnet.session.Session.start`,
+        read function returns only frames received after the calling
+        :class:`nixnet.session.Session.start`.
+
+        Args:
+            None
+
+        Returns:
+            None
+        """
         _funcs.nx_flush(self._handle)
 
     def wait_for_transmit_complete(self, timeout=10):
+        """Wait for transmition to complete.
+
+        All frames written for the session have been transmitted on the bus.
+        This condition applies to CAN, LIN, and FlexRay. This condition is state
+        based, and the state is Boolean (true/false).
+
+        Args:
+            timeout: A float representing the maximum amount of time to wait in
+                seconds.
+
+        Returns:
+            None
+        """
         _funcs.nx_wait(self._handle, constants.Condition.TRANSMIT_COMPLETE, 0, timeout)
 
     def wait_for_intf_communicating(self, timeout=10):
+        """Wait for the interface to begin communication on the network.
+
+        If a start trigger is configured for the interface, this first waits for
+        the trigger. Once the interface is started, this waits for the
+        protocol's communication state to transition to a value that indicates
+        communication with remote nodes.
+
+        After this wait succeeds, calls to 'read_state' will return:
+            :class:`nixnet.constants.ReadState.CAN_COMM`: :class:`nixnet.constants.ReadState.CAN_COMM.ERROR_ACTIVE`
+            :class:`nixnet.constants.ReadState.CAN_COMM`: :class:`nixnet.constants.ReadState.CAN_COMM.ERROR_PASSIVE`
+            :class:`nixnet.constants.ReadState.TIME_COMMUNICATING`: Valid time for communication (invalid time of 0 prior)
+
+        Args:
+            timeout: A float representing the maximum amount of time to wait in
+                seconds.
+
+        Returns:
+            None
+        """
         _funcs.nx_wait(self._handle, constants.Condition.INTF_COMMUNICATING, 0, timeout)
 
     def wait_for_intf_remote_wakeup(self, timeout=10):
+        """Wait for interface remote wakeup.
+
+        Wait for the interface to wakeup due to activity by a remote node on the
+        network. This wait is used for CAN, when you set the 'can_tcvr_state'
+        property to :class:`nixnet.constants.CanTcvrState.SLEEP`. Although the
+        interface itself is ready to communicate, this places the transceiver
+        into a sleep state. When a remote CAN node transmits a frame, the
+        transceiver wakes up, and communication is restored. This wait detects
+        that remote wakeup.
+
+        This wait is used for LIN when you set 'lin_sleep' property to
+        :class:`nixnet.constants.LinSleep.REMOTE_SLEEP` or
+        :class:`nixnet.constants.LinSleep.LOCAL_SLEEP`. When asleep, if a remote
+        LIN ECU transmits the wakeup pattern (break), the XNET LIN interface
+        detects this transmission and wakes up. This wait detects that remote wakeup.
+
+        Args:
+            timeout: A float representing the maximum amount of time to wait in
+                seconds.
+
+        Returns:
+            None
+        """
         _funcs.nx_wait(self._handle, constants.Condition.INTF_REMOTE_WAKEUP, 0, timeout)
 
     def connect_terminals(self, source, destination):
+        """Connect terminals on the XNET interface.
+
+        This function connects a source terminal to a destination terminal on
+        the interface hardware. The XNET terminal represents an external or
+        internal hardware connection point on a National Instruments XNET
+        hardware product. External terminals include PXI Trigger lines for a PXI
+        card, RTSI terminals for a PCI card, or the single external terminal for
+        a C Series module. Internal terminals include timebases (clocks) and
+        logical entities such as a start trigger.
+
+        The terminal inputs use the Terminal I/O names. Typically, one of the
+        pair is an internal and the other an external.
+
+        Args:
+            source: A string repesenting the connection source name.
+            destination: A string repesenting the connection destination name.
+
+        Returns:
+            None
+        """
         _funcs.nx_connect_terminals(self._handle, source, destination)
 
     def disconnect_terminals(self, source, destination):
+        """Disconnect terminals on the XNET interface.
+
+        This function disconnects a specific pair of source/destination terminals
+        previously connected with :class:`nixnet.session.Session.connect_terminals`.
+
+        When the final session for a given interface is cleared, NI-XNET
+        automatically disconnects all terminal connections for that interface.
+        Therefore, 'disconnect_terminals' is not required for most applications.
+
+        This function typically is used to change terminal connections
+        dynamically while an application is running. To disconnect a terminal,
+        you first must stop the interface using :class:`nixnet.session.Session.stop`
+        with the Interface Only scope. Then you can call 'disconnect_terminals'
+        and :class:`nixnet.session.Session.connect_terminals` to adjust terminal
+        connections. Finally, you can call :class:`nixnet.session.Session.start` with
+        the Interface Only scope to restart the interface.
+
+        You can disconnect only a terminal that has been previously connected.
+        Attempting to disconnect a nonconnected terminal results in an error.
+
+        Args:
+            source: A string repesenting the connection source name.
+            destination: A string repesenting the connection destination name.
+
+        Returns:
+            None
+        """
         _funcs.nx_disconnect_terminals(self._handle, source, destination)
 
     @property
@@ -177,7 +443,23 @@ class FrameInStreamSession(SessionBase):
             interface,
             database_name=':memory:',
             cluster_name=''):
-        "http://zone.ni.com/reference/en-XX/help/372841N-01/nixnet/nxcreatesession/"
+        """Create a Frame Input Stream session.
+
+        This function creates a Frame Input Stream session using the named
+        references to database objects.
+
+        Args:
+            interface: The XNET Interface to use for this session.
+            database_name: The XNET database to use for interface configuration.
+                The database name must use the <alias> or <filepath> syntax
+                (refer to Databases).
+            cluster_name: The XNET cluster to use for interface configuration.
+                The name must specify a cluster from the database given in the
+                database_name parameter.
+
+        Returns:
+            A Frame Input Stream session object.
+        """
         flattened_list = _utils.flatten_items(None)
         SessionBase.__init__(
             self,
@@ -200,7 +482,23 @@ class FrameOutStreamSession(SessionBase):
             interface,
             database_name=':memory:',
             cluster_name=''):
-        "http://zone.ni.com/reference/en-XX/help/372841N-01/nixnet/nxcreatesession/"
+        """Create a Frame Input Stream session.
+
+        This function creates a Frame Output Stream session using the named
+        references to database objects.
+
+        Args:
+            interface: The XNET Interface to use for this session.
+            database_name: The XNET database to use for interface configuration.
+                The database name must use the <alias> or <filepath> syntax
+                (refer to Databases).
+            cluster_name: The XNET cluster to use for interface configuration.
+                The name must specify a cluster from the database given in the
+                database_name parameter.
+
+        Returns:
+            A Frame Output Stream session object.
+        """
         flattened_list = _utils.flatten_items(None)
         SessionBase.__init__(
             self,
@@ -224,7 +522,31 @@ class FrameInQueuedSession(SessionBase):
             database_name,
             cluster_name,
             frame):
-        "http://zone.ni.com/reference/en-XX/help/372841N-01/nixnet/nxcreatesession/"
+        """Create a Frame Input Queued session.
+
+        This function creates a Frame Input Queued session using the named
+        references to database objects.
+
+        Args:
+            interface: The XNET Interface to use for this session.
+            database_name: The XNET database to use for interface configuration.
+                The database name must use the <alias> or <filepath> syntax
+                (refer to Databases).
+            cluster_name: The XNET cluster to use for interface configuration.
+                The name must specify a cluster from the database given in the
+                database_name parameter. If it is left blank, the cluster is
+                extracted from the 'frame' parameter.
+            frame: A string describing one XNET Frame or PDU name. This name
+                must be one of the following options, whichever uniquely
+                identifies a frame within the database given:
+                        -<Frame>
+                        -<Cluster>.<Frame>
+                        -<PDU>
+                        -<Cluster>.<PDU>
+
+        Returns:
+            A Frame Input Queued session object.
+        """
         flattened_list = _utils.flatten_items(frame)
         SessionBase.__init__(
             self,
@@ -248,7 +570,31 @@ class FrameOutQueuedSession(SessionBase):
             database_name,
             cluster_name,
             frame):
-        "http://zone.ni.com/reference/en-XX/help/372841N-01/nixnet/nxcreatesession/"
+        """Create a Frame Output Queued session.
+
+        This function creates a Frame Output Stream session using the named
+        references to database objects.
+
+        Args:
+            interface: The XNET Interface to use for this session.
+            database_name: The XNET database to use for interface configuration.
+                The database name must use the <alias> or <filepath> syntax
+                (refer to Databases).
+            cluster_name: The XNET cluster to use for interface configuration.
+                The name must specify a cluster from the database given in the
+                database_name parameter. If it is left blank, the cluster is
+                extracted from the 'frame' parameter.
+            frame: A string describing one XNET Frame or PDU name. This name
+                must be one of the following options, whichever uniquely
+                identifies a frame within the database given:
+                        -<Frame>
+                        -<Cluster>.<Frame>
+                        -<PDU>
+                        -<Cluster>.<PDU>
+
+        Returns:
+            A Frame Output Queued session object.
+        """
         flattened_list = _utils.flatten_items(frame)
         SessionBase.__init__(
             self,
@@ -272,7 +618,33 @@ class FrameInSinglePointSession(SessionBase):
             database_name,
             cluster_name,
             frames):
-        "http://zone.ni.com/reference/en-XX/help/372841N-01/nixnet/nxcreatesession/"
+        """Create a Frame Input Single-Point session.
+
+        This function creates a Frame Input Single-Point session using the named
+        references to database objects.
+
+        Args:
+            interface: The XNET Interface to use for this session.
+            database_name: The XNET database to use for interface configuration.
+                The database name must use the <alias> or <filepath> syntax
+                (refer to Databases).
+            cluster_name: The XNET cluster to use for interface configuration.
+                The name must specify a cluster from the database given in the
+                database_name parameter. If it is left blank, the cluster is
+                extracted from the 'frames' parameter.
+            frames: A list of strings describing frames for the session. The
+                list syntax is as follows:
+                    List contains one or more XNET Frame or PDU names. Each name
+                    must be one of the following options, whichever uniquely
+                    identifies a frame within the database given:
+                        -<Frame>
+                        -<Cluster>.<Frame>
+                        -<PDU>
+                        -<Cluster>.<PDU>
+
+        Returns:
+            A Frame Input Single-Point session object.
+        """
         flattened_list = _utils.flatten_items(frames)
         SessionBase.__init__(
             self,
@@ -296,7 +668,33 @@ class FrameOutSinglePointSession(SessionBase):
             database_name,
             cluster_name,
             frames):
-        "http://zone.ni.com/reference/en-XX/help/372841N-01/nixnet/nxcreatesession/"
+        """Create a Frame Output Single-Point session.
+
+        This function creates a Frame Output Single-Point session using the named
+        references to database objects.
+
+        Args:
+            interface: The XNET Interface to use for this session.
+            database_name: The XNET database to use for interface configuration.
+                The database name must use the <alias> or <filepath> syntax
+                (refer to Databases).
+            cluster_name: The XNET cluster to use for interface configuration.
+                The name must specify a cluster from the database given in the
+                database_name parameter. If it is left blank, the cluster is
+                extracted from the 'frames' parameter.
+            frames: A list of strings describing frames for the session. The
+                list syntax is as follows:
+                    List contains one or more XNET Frame or PDU names. Each name
+                    must be one of the following options, whichever uniquely
+                    identifies a frame within the database given:
+                        -<Frame>
+                        -<Cluster>.<Frame>
+                        -<PDU>
+                        -<Cluster>.<PDU>
+
+        Returns:
+            A Frame Output Single-Point session object.
+        """
         flattened_list = _utils.flatten_items(frames)
         SessionBase.__init__(
             self,
@@ -320,7 +718,37 @@ class SignalInSinglePointSession(SessionBase):
             database_name,
             cluster_name,
             signals):
-        "http://zone.ni.com/reference/en-XX/help/372841N-01/nixnet/nxcreatesession/"
+        """Create a Signal Input Single-Point session.
+
+        This function creates a Signal Input Single-Point session using the named
+        references to database objects.
+
+        Args:
+            interface: The XNET Interface to use for this session.
+            database_name: The XNET database to use for interface configuration.
+                The database name must use the <alias> or <filepath> syntax
+                (refer to Databases).
+            cluster_name: The XNET cluster to use for interface configuration.
+                The name must specify a cluster from the database given in the
+                database_name parameter. If it is left blank, the cluster is
+                extracted from the signals parameter.
+            signals: A list of strings describing signals for the session. The
+                list syntax is as follows:
+                    List contains one or more XNET Signal names. Each name must
+                    be one of the following options, whichever uniquely
+                    identifies a signal within the database given:
+                        -<Signal>
+                        -<Frame>.<Signal>
+                        -<Cluster>.<Frame>.<Signal>
+                        -<PDU>.<Signal>
+                        -<Cluster>.<PDU>.<Signal>
+                    List may also contain one or more trigger signals. For
+                    information about trigger signals, refer to Signal Output
+                    Single-Point Mode or Signal Input Single-Point Mode.
+
+        Returns:
+            A Signal Input Single-Point session object.
+        """
         flattened_list = _utils.flatten_items(signals)
         SessionBase.__init__(
             self,
@@ -344,7 +772,37 @@ class SignalOutSinglePointSession(SessionBase):
             database_name,
             cluster_name,
             signals):
-        "http://zone.ni.com/reference/en-XX/help/372841N-01/nixnet/nxcreatesession/"
+        """Create a Signal Output Single-Point session.
+
+        This function creates a Signal Output Single-Point session using the named
+        references to database objects.
+
+        Args:
+            interface: The XNET Interface to use for this session.
+            database_name: The XNET database to use for interface configuration.
+                The database name must use the <alias> or <filepath> syntax
+                (refer to Databases).
+            cluster_name: The XNET cluster to use for interface configuration.
+                The name must specify a cluster from the database given in the
+                database_name parameter. If it is left blank, the cluster is
+                extracted from the signals parameter.
+            signals: A list of strings describing signals for the session. The
+                list syntax is as follows:
+                    List contains one or more XNET Signal names. Each name must
+                    be one of the following options, whichever uniquely
+                    identifies a signal within the database given:
+                        -<Signal>
+                        -<Frame>.<Signal>
+                        -<Cluster>.<Frame>.<Signal>
+                        -<PDU>.<Signal>
+                        -<Cluster>.<PDU>.<Signal>
+                    List may also contain one or more trigger signals. For
+                    information about trigger signals, refer to Signal Output
+                    Single-Point Mode or Signal Output Single-Point Mode.
+
+        Returns:
+            A Signal Output Single-Point session object.
+        """
         flattened_list = _utils.flatten_items(signals)
         SessionBase.__init__(
             self,

--- a/nixnet/session.py
+++ b/nixnet/session.py
@@ -22,6 +22,8 @@ __all__ = [
     "FrameOutStreamSession",
     "FrameInQueuedSession",
     "FrameOutQueuedSession",
+    "FrameInSinglePointSession",
+    "FrameOutSinglePointSession",
     "SignalInSinglePointSession",
     "SignalOutSinglePointSession"]
 

--- a/nixnet/session.py
+++ b/nixnet/session.py
@@ -68,19 +68,21 @@ class SessionBase(object):
         specified in 'list' from the database named in 'database_name'.
 
         Args:
-            database_name: The XNET database to use for interface configuration.
-                The database name must use the <alias> or <filepath> syntax
-                (refer to Databases).
-            cluster_name: The XNET cluster to use for interface configuration.
-                The name must specify a cluster from the database given in the
-                database_name parameter. If it is left blank, the cluster is
-                extracted from the list parameter; this is not allowed for modes
-                of :class:`nixnet.constants.CreateSessionMode.FRAME_IN_STREAM`
+            database_name: A string representing the XNET database to use for
+                interface configuration. The database name must use the <alias>
+                or <filepath> syntax (refer to Databases).
+            cluster_name: A string representing the XNET cluster to use for
+                interface configuration. The name must specify a cluster from
+                the database given in the database_name parameter. If it is left
+                blank, the cluster is extracted from the list parameter; this is
+                not allowed for modes of
+                :class:`nixnet.constants.CreateSessionMode.FRAME_IN_STREAM`
                 or :class:`nixnet.constants.CreateSessionMode.FRAME_OUT_STREAM`.
             list: A list of strings describing signals or frames for the session.
                 The list syntax depends on the mode. Refer to mode spefic
                 session classes defined below for 'list' syntax.
-            interface_name: The XNET Interface to use for this session. If Mode is
+            interface_name: A string representing the XNET Interface to use for
+                this session. If Mode is
                 :class:`nixnet.constants.CreateSessionMode.SIGNAL_CONVERSION_SINGLE_POINT`,
                 this input is ignored. You can set it to an empty string.
             mode: The session mode. See :class:`nixnet._enums.CreateSessionMode`.
@@ -335,8 +337,8 @@ class SessionBase(object):
         pair is an internal and the other an external.
 
         Args:
-            source: A string repesenting the connection source name.
-            destination: A string repesenting the connection destination name.
+            source: A string representing the connection source name.
+            destination: A string representing the connection destination name.
 
         Returns:
             None
@@ -365,8 +367,8 @@ class SessionBase(object):
         Attempting to disconnect a nonconnected terminal results in an error.
 
         Args:
-            source: A string repesenting the connection source name.
-            destination: A string repesenting the connection destination name.
+            source: A string representing the connection source name.
+            destination: A string representing the connection destination name.
 
         Returns:
             None
@@ -451,13 +453,14 @@ class FrameInStreamSession(SessionBase):
         references to database objects.
 
         Args:
-            interface_name: The XNET Interface to use for this session.
-            database_name: The XNET database to use for interface configuration.
-                The database name must use the <alias> or <filepath> syntax
-                (refer to Databases).
-            cluster_name: The XNET cluster to use for interface configuration.
-                The name must specify a cluster from the database given in the
-                database_name parameter.
+            interface_name: A string representing the XNET Interface to use for
+                this session.
+            database_name: A string representing the XNET database to use for
+                interface configuration. The database name must use the <alias>
+                or <filepath> syntax (refer to Databases).
+            cluster_name: A string representing the XNET cluster to use for
+                interface configuration. The name must specify a cluster from
+                the database given in the database_name parameter.
 
         Returns:
             A Frame Input Stream session object.
@@ -490,13 +493,14 @@ class FrameOutStreamSession(SessionBase):
         references to database objects.
 
         Args:
-            interface_name: The XNET Interface to use for this session.
-            database_name: The XNET database to use for interface configuration.
-                The database name must use the <alias> or <filepath> syntax
-                (refer to Databases).
-            cluster_name: The XNET cluster to use for interface configuration.
-                The name must specify a cluster from the database given in the
-                database_name parameter.
+            interface_name: A string representing the XNET Interface to use for
+                this session.
+            database_name: A string representing the XNET database to use for
+                interface configuration. The database name must use the <alias>
+                or <filepath> syntax (refer to Databases).
+            cluster_name: A string representing the XNET cluster to use for
+                interface configuration. The name must specify a cluster from
+                the database given in the database_name parameter.
 
         Returns:
             A Frame Output Stream session object.
@@ -530,14 +534,15 @@ class FrameInQueuedSession(SessionBase):
         references to database objects.
 
         Args:
-            interface_name: The XNET Interface to use for this session.
-            database_name: The XNET database to use for interface configuration.
-                The database name must use the <alias> or <filepath> syntax
-                (refer to Databases).
-            cluster_name: The XNET cluster to use for interface configuration.
-                The name must specify a cluster from the database given in the
-                database_name parameter. If it is left blank, the cluster is
-                extracted from the 'frame' parameter.
+            interface_name: A string representing the XNET Interface to use for
+                this session.
+            database_name: A string representing the XNET database to use for
+                interface configuration. The database name must use the <alias>
+                or <filepath> syntax(refer to Databases).
+            cluster_name: A string representing the XNET cluster to use for
+                interface configuration. The name must specify a cluster from
+                the database given in the database_name parameter. If it is left
+                blank, the cluster is extracted from the 'frame' parameter.
             frame: A string describing one XNET Frame or PDU name. This name
                 must be one of the following options, whichever uniquely
                 identifies a frame within the database given:
@@ -578,14 +583,15 @@ class FrameOutQueuedSession(SessionBase):
         references to database objects.
 
         Args:
-            interface_name: The XNET Interface to use for this session.
-            database_name: The XNET database to use for interface configuration.
-                The database name must use the <alias> or <filepath> syntax
-                (refer to Databases).
-            cluster_name: The XNET cluster to use for interface configuration.
-                The name must specify a cluster from the database given in the
-                database_name parameter. If it is left blank, the cluster is
-                extracted from the 'frame' parameter.
+            interface_name: A string representing the XNET Interface to use for
+                this session.
+            database_name: A string representing the XNET database to use for
+                interface configuration. The database name must use the <alias>
+                or <filepath> syntax (refer to Databases).
+            cluster_name: A string representing the XNET cluster to use for
+                interface configuration. The name must specify a cluster from
+                the database given in the database_name parameter. If it is left
+                blank, the cluster is extracted from the 'frame' parameter.
             frame: A string describing one XNET Frame or PDU name. This name
                 must be one of the following options, whichever uniquely
                 identifies a frame within the database given:
@@ -626,14 +632,15 @@ class FrameInSinglePointSession(SessionBase):
         references to database objects.
 
         Args:
-            interface_name: The XNET Interface to use for this session.
-            database_name: The XNET database to use for interface configuration.
-                The database name must use the <alias> or <filepath> syntax
-                (refer to Databases).
-            cluster_name: The XNET cluster to use for interface configuration.
-                The name must specify a cluster from the database given in the
-                database_name parameter. If it is left blank, the cluster is
-                extracted from the 'frames' parameter.
+            interface_name: A string representing the XNET Interface to use for
+                this session.
+            database_name: A string representing the XNET database to use for
+                interface configuration. The database name must use the <alias>
+                or <filepath> syntax (refer to Databases).
+            cluster_name: A string representing the XNET cluster to use for
+                interface configuration. The name must specify a cluster from
+                the database given in the database_name parameter. If it is left
+                blank, the cluster is extracted from the 'frames' parameter.
             frames: A list of strings describing frames for the session. The
                 list syntax is as follows:
                     List contains one or more XNET Frame or PDU names. Each name
@@ -676,14 +683,15 @@ class FrameOutSinglePointSession(SessionBase):
         references to database objects.
 
         Args:
-            interface_name: The XNET Interface to use for this session.
-            database_name: The XNET database to use for interface configuration.
-                The database name must use the <alias> or <filepath> syntax
-                (refer to Databases).
-            cluster_name: The XNET cluster to use for interface configuration.
-                The name must specify a cluster from the database given in the
-                database_name parameter. If it is left blank, the cluster is
-                extracted from the 'frames' parameter.
+            interface_name: A string representing the XNET Interface to use for
+                this session.
+            database_name: A string representing the XNET database to use for
+                interface configuration. The database name must use the <alias>
+                or <filepath> syntax (refer to Databases).
+            cluster_name: A string representing the XNET cluster to use for
+                interface configuration. The name must specify a cluster from
+                the database given in the database_name parameter. If it is left
+                blank, the cluster is extracted from the 'frames' parameter.
             frames: A list of strings describing frames for the session. The
                 list syntax is as follows:
                     List contains one or more XNET Frame or PDU names. Each name
@@ -726,14 +734,15 @@ class SignalInSinglePointSession(SessionBase):
         references to database objects.
 
         Args:
-            interface_name: The XNET Interface to use for this session.
-            database_name: The XNET database to use for interface configuration.
-                The database name must use the <alias> or <filepath> syntax
-                (refer to Databases).
-            cluster_name: The XNET cluster to use for interface configuration.
-                The name must specify a cluster from the database given in the
-                database_name parameter. If it is left blank, the cluster is
-                extracted from the signals parameter.
+            interface_name: A string representing the XNET Interface to use for
+                this session.
+            database_name: A string representing the XNET database to use for
+                interface configuration. The database name must use the <alias>
+                or <filepath> syntax (refer to Databases).
+            cluster_name: A string representing the XNET cluster to use for
+                interface configuration. The name must specify a cluster from
+                the database given in the database_name parameter. If it is left
+                blank, the cluster is extracted from the signals parameter.
             signals: A list of strings describing signals for the session. The
                 list syntax is as follows:
                     List contains one or more XNET Signal names. Each name must
@@ -780,14 +789,15 @@ class SignalOutSinglePointSession(SessionBase):
         references to database objects.
 
         Args:
-            interface_name: The XNET Interface to use for this session.
-            database_name: The XNET database to use for interface configuration.
-                The database name must use the <alias> or <filepath> syntax
-                (refer to Databases).
-            cluster_name: The XNET cluster to use for interface configuration.
-                The name must specify a cluster from the database given in the
-                database_name parameter. If it is left blank, the cluster is
-                extracted from the signals parameter.
+            interface_name: A string representing the XNET Interface to use for
+                this session.
+            database_name: A string representing the XNET database to use for
+                interface configuration. The database name must use the <alias>
+                or <filepath> syntax (refer to Databases).
+            cluster_name: A string representing the XNET cluster to use for
+                interface configuration. The name must specify a cluster from
+                the database given in the database_name parameter. If it is left
+                blank, the cluster is extracted from the signals parameter.
             signals: A list of strings describing signals for the session. The
                 list syntax is as follows:
                     List contains one or more XNET Signal names. Each name must

--- a/nixnet/session.py
+++ b/nixnet/session.py
@@ -3,17 +3,12 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
-import warnings
-
 from nixnet import _funcs
-from nixnet import _props
 from nixnet import _utils
 from nixnet import constants
-from nixnet import errors
 
+from nixnet._session import base
 from nixnet._session import frames as session_frames
-from nixnet._session import intf
-from nixnet._session import j1939
 from nixnet._session import signals as session_signals
 
 
@@ -28,419 +23,35 @@ __all__ = [
     "SignalOutSinglePointSession"]
 
 
-class SessionBase(object):
-    """Session base object.
+class FrameInStreamSession(base.SessionBase):
+    """Frame Input Stream session.
 
-    The NI-XNET session represents a connection between your National Instruments
-    CAN/FlexRay/LIN hardware and hardware products on the external network.
+    This session reads all frames received from the network using a single
+    stream. It typically is used for analyzing and/or logging all frame traffic
+    in the network.
 
-    In addition to read/write of I/O data, you can use the session to interact
-    with the network in other ways. For example, 'read_state' includes
-    selections to read the state of communication, such as whether communication
-    has stopped due to error detection defined by the protocol standard.
+    The input data is returned as a list of frames. Because all frames are
+    returned, your application must evaluate identification in each frame (such
+    as a CAN identifier or FlexRay slot/cycle/channel) to interpret the frame
+    payload data.
 
-    You can use sessions for multiple hardware interfaces. For each interface,
-    you can use multiple input sessions and multiple output sessions
-    simultaneously. The sessions can use different modes. For example, you can
-    use a Signal Input Single-Point session at the same time you use a Frame
-    Input Stream session.
+    Previously, you could use only one Frame Input Stream session for a given
+    interface. Now, multiple Frame Input Stream sessions can be open at the same
+    time on CAN and LIN interfaces.
 
-    The limitations on sessions relate primarily to a specific frame or its
-    signals. For example, if you create a
-    class:`nixnet.session.FrameOutQueuedSession` session for frame_a, then create
-    a class:`nixnet.session.SignalOutSinglePointSession` session for
-    frame_a.signal_b (a signal in frame_a), NI-XNET returns an error. This
-    combination of sessions is not allowed, because writing data for the same
-    frame with two sessions would result in inconsistent sequences of data on
-    the network.
+    While using one or more Frame Input Stream sessions, you can use other
+    sessions with different input modes. Received frames are copied to Frame
+    Input Stream sessions in addition to any other applicable input session. For
+    example, if you create a Frame Input Single-Point session for frame_a, then
+    create a Frame Input Stream session, when frame_a is received, its data is
+    returned from the call to read function of both sessions. This duplication
+    of incoming frames enables you to analyze overall traffic while running a
+    higher level application that uses specific frame or signal data.
+
+    When used with a FlexRay interface, frames from both channels are returned.
+    For example, if a frame is received in a static slot on both channel A and
+    channel B, two frames are returned from the read function.
     """
-
-    def __init__(
-            self,
-            database_name,
-            cluster_name,
-            list,
-            interface_name,
-            mode):
-        """Create an XNET session at run time using named references to database objects.
-
-        This function creates a session using the named database objects
-        specified in 'list' from the database named in 'database_name'.
-
-        Args:
-            database_name: A string representing the XNET database to use for
-                interface configuration. The database name must use the <alias>
-                or <filepath> syntax (refer to Databases).
-            cluster_name: A string representing the XNET cluster to use for
-                interface configuration. The name must specify a cluster from
-                the database given in the database_name parameter. If it is left
-                blank, the cluster is extracted from the list parameter; this is
-                not allowed for modes of
-                :class:`nixnet.constants.CreateSessionMode.FRAME_IN_STREAM`
-                or :class:`nixnet.constants.CreateSessionMode.FRAME_OUT_STREAM`.
-            list: A list of strings describing signals or frames for the session.
-                The list syntax depends on the mode. Refer to mode spefic
-                session classes defined below for 'list' syntax.
-            interface_name: A string representing the XNET Interface to use for
-                this session. If Mode is
-                :class:`nixnet.constants.CreateSessionMode.SIGNAL_CONVERSION_SINGLE_POINT`,
-                this input is ignored. You can set it to an empty string.
-            mode: The session mode. See :class:`nixnet._enums.CreateSessionMode`.
-
-        Returns:
-            A Session object.
-        """
-        self._handle = None  # To satisfy `__del__` in case nx_create_session throws
-        self._handle = _funcs.nx_create_session(database_name, cluster_name, list, interface_name, mode)
-        self._intf = intf.Interface(self._handle)
-        self._j1939 = j1939.J1939(self._handle)
-
-    def __del__(self):
-        if self._handle is not None:
-            warnings.warn(
-                'Session was not explicitly closed before it was destructed. '
-                'Resources on the device may still be reserved.',
-                errors.XnetResourceWarning)
-
-    def __enter__(self):
-        return self
-
-    def __exit__(self, type, value, traceback):
-        self.close()
-
-    def __eq__(self, other):
-        if isinstance(other, self.__class__):
-            return self._handle == other._handle
-        return False
-
-    def __ne__(self, other):
-        return not self.__eq__(other)
-
-    def __hash__(self):
-        return hash(self._handle)
-
-    def __repr__(self):
-        return 'Session(handle={0})'.format(self._handle)
-
-    def close(self):
-        """Close (clear) the XNET session.
-
-        This function stops communication for the session and releases all
-        resources the session uses. It internally calls
-        :class:`nixnet.session.Session.stop` with normal scope, so if this is the
-        last session using the interface, communication stops.
-
-        You typically use 'close' when you need to close the existing session to
-        create a new session that uses the same objects. For example, if you
-        create a session for a frame named frame_a using Frame Output
-        Single-Point mode, then you create a second session for frame_a using
-        Frame Output Queued mode, the second call to the session constructor
-        returns an error, because frame_a can be accessed using only one output
-        mode. If you call 'close' before the second constructor call, you can
-        close the previous use of frame_a to create the new session.
-
-        Args:
-            None
-
-        Returns:
-            None
-        """
-        if self._handle is None:
-            warnings.warn(
-                'Attempting to close NI-XNET session but session was already '
-                'closed', errors.XnetResourceWarning)
-            return
-
-        _funcs.nx_clear(self._handle)
-
-        self._handle = None
-
-    def start(self, scope=constants.StartStopScope.NORMAL):
-        """Start communication for the XNET session.
-
-        Because the session is started automatically by default, this function
-        is optional. This function is for more advanced applications to start
-        multiple sessions in a specific order. For more information about the
-        automatic start feature, refer to the
-        :class:`nixnet.session.Session.auto_start` property.
-
-        For each physical interface, the NI-XNET hardware is divided into two logical units:
-            Sessions: You can create one or more sessions, each of which contains
-                frames or signals to be transmitted (or received) on the bus.
-            Interface: The interface physically connects to the bus and transmits
-                (or receives) data for the sessions.
-
-        You can start each logical unit separately. When a session is started,
-        all contained frames or signals are placed in a state where they are
-        ready to communicate. When the interface is started, it takes data from
-        all started sessions to communicate with other nodes on the bus. For a
-        specification of the state models for the session and interface, refer
-        to State Models.
-
-        If an output session starts before you write data, or you read an input
-        session before it receives a frame, default data is used. For more
-        information, refer to the XNET Frame Default Payload and XNET Signal
-        Default Value properties.
-
-        Args:
-            scope: Describes the impact of this operation on the underlying
-                state models for the session and its interface.
-                See :class:`nixnet._enums.StartStopScope`.
-
-        Returns:
-            None
-        """
-        _funcs.nx_start(self._handle, scope)
-
-    def stop(self, scope=constants.StartStopScope.NORMAL):
-        """Stop communication for the XNET session.
-
-        Because the session is stopped automatically when closed (cleared),
-        this function is optional.
-
-        For each physical interface, the NI-XNET hardware is divided into two logical units:
-            Sessions: You can create one or more sessions, each of which contains
-                frames or signals to be transmitted (or received) on the bus.
-            Interface: The interface physically connects to the bus and transmits
-                (or receives) data for the sessions.
-
-        You can stop each logical unit separately. When a session is stopped,
-        all contained frames or signals are placed in a state where they are no
-        longer ready to communicate. When the interface is stopped, it no longer
-        takes data from sessions to communicate with other nodes on the bus. For
-        a specification of the state models for the session and interface, refer
-        to State Models.
-
-        Args:
-            scope: Describes the impact of this operation on the underlying
-                state models for the session and its interface.
-                See :class:`nixnet._enums.StartStopScope`.
-
-        Returns:
-            None
-        """
-        _funcs.nx_stop(self._handle, scope)
-
-    def flush(self):
-        """Flushes (empties) all XNET session queues.
-
-        With the exception of single-point modes, all sessions use queues to
-        store frames. For input modes, the queues store frame values (or
-        corresponding signal values) that have been received, but not obtained
-        by calling the read function. For output sessions, the queues store
-        frame values provided to write function, but not transmitted successfully.
-
-        :class:`nixnet.session.Session.start` and :class:`nixnet.session.Session.stop`
-        have no effect on these queues. Use 'flush' to discard all values in the
-        session's queues.
-
-        For example, if you call a write function to write three frames, then
-        immediately call :class:`nixnet.session.Session.stop`, then call
-        :class:`nixnet.session.Session.start` a few seconds later, the three frames
-        transmit. If you call 'flush' between :class:`nixnet.session.Session.stop` and
-        :class:`nixnet.session.Session.start`, no frames transmit.
-
-        As another example, if you receive three frames, then call
-        :class:`nixnet.session.Session.stop`, the three frames remains in the queue.
-        If you call :class:`nixnet.session.Session.start` a few seconds later, then
-        call a read function, you obtain the three frames received earlier,
-        potentially followed by other frames received after calling
-        :class:`nixnet.session.Session.start`. If you call 'flush' between
-        :class:`nixnet.session.Session.stop` and :class:`nixnet.session.Session.start`,
-        read function returns only frames received after the calling
-        :class:`nixnet.session.Session.start`.
-
-        Args:
-            None
-
-        Returns:
-            None
-        """
-        _funcs.nx_flush(self._handle)
-
-    def wait_for_transmit_complete(self, timeout=10):
-        """Wait for transmition to complete.
-
-        All frames written for the session have been transmitted on the bus.
-        This condition applies to CAN, LIN, and FlexRay. This condition is state
-        based, and the state is Boolean (true/false).
-
-        Args:
-            timeout: A float representing the maximum amount of time to wait in
-                seconds.
-
-        Returns:
-            None
-        """
-        _funcs.nx_wait(self._handle, constants.Condition.TRANSMIT_COMPLETE, 0, timeout)
-
-    def wait_for_intf_communicating(self, timeout=10):
-        """Wait for the interface to begin communication on the network.
-
-        If a start trigger is configured for the interface, this first waits for
-        the trigger. Once the interface is started, this waits for the
-        protocol's communication state to transition to a value that indicates
-        communication with remote nodes.
-
-        After this wait succeeds, calls to 'read_state' will return:
-            :class:`nixnet.constants.ReadState.CAN_COMM`: :class:`nixnet.constants.ReadState.CAN_COMM.ERROR_ACTIVE`
-            :class:`nixnet.constants.ReadState.CAN_COMM`: :class:`nixnet.constants.ReadState.CAN_COMM.ERROR_PASSIVE`
-            :class:`nixnet.constants.ReadState.TIME_COMMUNICATING`: Valid time for communication (invalid time of 0 prior)
-
-        Args:
-            timeout: A float representing the maximum amount of time to wait in
-                seconds.
-
-        Returns:
-            None
-        """
-        _funcs.nx_wait(self._handle, constants.Condition.INTF_COMMUNICATING, 0, timeout)
-
-    def wait_for_intf_remote_wakeup(self, timeout=10):
-        """Wait for interface remote wakeup.
-
-        Wait for the interface to wakeup due to activity by a remote node on the
-        network. This wait is used for CAN, when you set the 'can_tcvr_state'
-        property to :class:`nixnet.constants.CanTcvrState.SLEEP`. Although the
-        interface itself is ready to communicate, this places the transceiver
-        into a sleep state. When a remote CAN node transmits a frame, the
-        transceiver wakes up, and communication is restored. This wait detects
-        that remote wakeup.
-
-        This wait is used for LIN when you set 'lin_sleep' property to
-        :class:`nixnet.constants.LinSleep.REMOTE_SLEEP` or
-        :class:`nixnet.constants.LinSleep.LOCAL_SLEEP`. When asleep, if a remote
-        LIN ECU transmits the wakeup pattern (break), the XNET LIN interface
-        detects this transmission and wakes up. This wait detects that remote wakeup.
-
-        Args:
-            timeout: A float representing the maximum amount of time to wait in
-                seconds.
-
-        Returns:
-            None
-        """
-        _funcs.nx_wait(self._handle, constants.Condition.INTF_REMOTE_WAKEUP, 0, timeout)
-
-    def connect_terminals(self, source, destination):
-        """Connect terminals on the XNET interface.
-
-        This function connects a source terminal to a destination terminal on
-        the interface hardware. The XNET terminal represents an external or
-        internal hardware connection point on a National Instruments XNET
-        hardware product. External terminals include PXI Trigger lines for a PXI
-        card, RTSI terminals for a PCI card, or the single external terminal for
-        a C Series module. Internal terminals include timebases (clocks) and
-        logical entities such as a start trigger.
-
-        The terminal inputs use the Terminal I/O names. Typically, one of the
-        pair is an internal and the other an external.
-
-        Args:
-            source: A string representing the connection source name.
-            destination: A string representing the connection destination name.
-
-        Returns:
-            None
-        """
-        _funcs.nx_connect_terminals(self._handle, source, destination)
-
-    def disconnect_terminals(self, source, destination):
-        """Disconnect terminals on the XNET interface.
-
-        This function disconnects a specific pair of source/destination terminals
-        previously connected with :class:`nixnet.session.Session.connect_terminals`.
-
-        When the final session for a given interface is cleared, NI-XNET
-        automatically disconnects all terminal connections for that interface.
-        Therefore, 'disconnect_terminals' is not required for most applications.
-
-        This function typically is used to change terminal connections
-        dynamically while an application is running. To disconnect a terminal,
-        you first must stop the interface using :class:`nixnet.session.Session.stop`
-        with the Interface Only scope. Then you can call 'disconnect_terminals'
-        and :class:`nixnet.session.Session.connect_terminals` to adjust terminal
-        connections. Finally, you can call :class:`nixnet.session.Session.start` with
-        the Interface Only scope to restart the interface.
-
-        You can disconnect only a terminal that has been previously connected.
-        Attempting to disconnect a nonconnected terminal results in an error.
-
-        Args:
-            source: A string representing the connection source name.
-            destination: A string representing the connection destination name.
-
-        Returns:
-            None
-        """
-        _funcs.nx_disconnect_terminals(self._handle, source, destination)
-
-    @property
-    def intf(self):
-        return self._intf
-
-    @property
-    def j1939(self):
-        return self._j1939
-
-    @property
-    def application_protocol(self):
-        return constants.AppProtocol(_props.get_session_application_protocol(self._handle))
-
-    @property
-    def auto_start(self):
-        return _props.get_session_auto_start(self._handle)
-
-    @auto_start.setter
-    def auto_start(self, value):
-        _props.set_session_auto_start(self._handle, value)
-
-    @property
-    def cluster_name(self):
-        return _props.get_session_cluster_name(self._handle)
-
-    @property
-    def database_name(self):
-        return _props.get_session_database_name(self._handle)
-
-    @property
-    def mode(self):
-        return constants.CreateSessionMode(_props.get_session_mode(self._handle))
-
-    @property
-    def num_pend(self):
-        return _props.get_session_num_pend(self._handle)
-
-    @property
-    def num_unused(self):
-        return _props.get_session_num_unused(self._handle)
-
-    @property
-    def payld_len_max(self):
-        return _props.get_session_payld_len_max(self._handle)
-
-    @property
-    def protocol(self):
-        return constants.Protocol(_props.get_session_protocol(self._handle))
-
-    @property
-    def queue_size(self):
-        return _props.get_session_queue_size(self._handle)
-
-    @queue_size.setter
-    def queue_size(self, value):
-        _props.set_session_queue_size(self._handle, value)
-
-    @property
-    def resamp_rate(self):
-        return _props.get_session_resamp_rate(self._handle)
-
-    @resamp_rate.setter
-    def resamp_rate(self, value):
-        _props.set_session_resamp_rate(self._handle, value)
-
-
-class FrameInStreamSession(SessionBase):
 
     def __init__(
             self,
@@ -466,7 +77,7 @@ class FrameInStreamSession(SessionBase):
             A Frame Input Stream session object.
         """
         flattened_list = _utils.flatten_items(None)
-        SessionBase.__init__(
+        base.SessionBase.__init__(
             self,
             database_name,
             cluster_name,
@@ -480,7 +91,44 @@ class FrameInStreamSession(SessionBase):
         return self._frames
 
 
-class FrameOutStreamSession(SessionBase):
+class FrameOutStreamSession(base.SessionBase):
+    """Frame Output Stream session.
+
+    This session transmits an arbitrary sequence of frame values using a single
+    stream. The values are not limited to a single frame in the database, but
+    can transmit any frame.
+
+    The data passed to the write frame function is a list of frame values,
+    each of which transmits as soon as possible. Frames transmit sequentially
+    (one after another).
+
+    This session is not supported for FlexRay.
+
+    Like Frame Input Stream sessions, you can create more than one Frame Output
+    Stream session for a given interface.
+
+    For CAN, frame values transmit on the network based entirely on the time
+    when you call the write frame function. The timing of each frame as
+    specified in the database is ignored. For example, if you provide four frame
+    values to the the write frame function, the first frame value transmits
+    immediately, followed by the next three values transmitted back to back. For
+    this session, the CAN frame payload length in the database is ignored, and
+    the write frame function is always used.
+
+    Similarly for LIN, frame values transmit on the network based entirely on
+    the time when you call the write frame function. The timing of each frame as
+    specified in the database is ignored. The LIN frame payload length in the
+    database is ignored, and the write frame function is always used. For LIN,
+    this session/mode is allowed only on the interface as master. If the payload
+    for a frame is empty, only the header part of the frame is transmitted. For
+    a nonempty payload, the header + response for the frame is transmitted. If a
+    frame for transmit is defined in the database (in-memory or otherwise), it
+    is transmitted using its database checksum type. If the frame for transmit
+    is not defined in the database, it is transmitted using enhanced checksum.
+
+    The frame values for this session are stored in a queue, such that every value
+    provided is transmitted.
+    """
 
     def __init__(
             self,
@@ -506,7 +154,7 @@ class FrameOutStreamSession(SessionBase):
             A Frame Output Stream session object.
         """
         flattened_list = _utils.flatten_items(None)
-        SessionBase.__init__(
+        base.SessionBase.__init__(
             self,
             database_name,
             cluster_name,
@@ -520,7 +168,21 @@ class FrameOutStreamSession(SessionBase):
         return self._frames
 
 
-class FrameInQueuedSession(SessionBase):
+class FrameInQueuedSession(base.SessionBase):
+    """Frame Input Queued session.
+
+    This session reads data from a dedicated queue per frame. It enables your
+    application to read a sequence of data specific to a frame (for example, a
+    CAN identifier).
+
+    You specify only one frame for the session, and the read frame function
+    returns values for that frame only. If you need sequential data for multiple
+    frames, create multiple sessions, one per frame.
+
+    The input data is returned as a list of frame values. These values
+    represent all values received for the frame since the previous call to the
+    read frame function.
+    """
 
     def __init__(
             self,
@@ -555,7 +217,7 @@ class FrameInQueuedSession(SessionBase):
             A Frame Input Queued session object.
         """
         flattened_list = _utils.flatten_items(frame)
-        SessionBase.__init__(
+        base.SessionBase.__init__(
             self,
             database_name,
             cluster_name,
@@ -569,7 +231,34 @@ class FrameInQueuedSession(SessionBase):
         return self._frames
 
 
-class FrameOutQueuedSession(SessionBase):
+class FrameOutQueuedSession(base.SessionBase):
+    """Frame Output Queued session.
+
+    This session provides a sequence of values for a single frame, for transmit
+    using that frame's timing as specified in the database.
+
+    The output data is provided as a list of frame values, to be transmitted
+    sequentially for the frame specified in the session.
+
+    You can only specify one frame for this session. To transmit sequential
+    values for multiple frames, use a different Frame Output Queued session for
+    each frame or use the Frame Output Stream session.
+
+    The frame values for this session are stored in a queue, such that every
+    value provided is transmitted.
+
+    For this session, NI-XNET transmits each frame according to its properties
+    in the database. Therefore, when you call the write frame function, the
+    number of payload bytes in each frame value must match that frame's Payload
+    Length property. The other frame value elements are ignored, so you can
+    leave them uninitialized. For CAN interfaces, if the number of payload bytes
+    you write is smaller than the Payload Length configured in the database, the
+    requested number of bytes transmits. If the number of payload bytes is
+    larger than the Payload Length configured in the database, the queue is
+    flushed and no frames transmit. For other interfaces, transmitting a number
+    of payload bytes different than the frame's payload may cause unexpected
+    results on the bus.
+    """
 
     def __init__(
             self,
@@ -604,7 +293,7 @@ class FrameOutQueuedSession(SessionBase):
             A Frame Output Queued session object.
         """
         flattened_list = _utils.flatten_items(frame)
-        SessionBase.__init__(
+        base.SessionBase.__init__(
             self,
             database_name,
             cluster_name,
@@ -618,7 +307,20 @@ class FrameOutQueuedSession(SessionBase):
         return self._frames
 
 
-class FrameInSinglePointSession(SessionBase):
+class FrameInSinglePointSession(base.SessionBase):
+    """Frame Input Single-Point session.
+
+    This session reads the most recent value received for each frame. It
+    typically is used for control or simulation applications that require lower
+    level access to frames (not signals).
+
+    This session does not use queues to store each received frame. If the
+    interface receives two frames prior to calling the read frame function, that
+    read returns signals for the second frame.
+
+    The input data is returned as a list of frames, one for each frame
+    specified for the session.
+    """
 
     def __init__(
             self,
@@ -655,7 +357,7 @@ class FrameInSinglePointSession(SessionBase):
             A Frame Input Single-Point session object.
         """
         flattened_list = _utils.flatten_items(frames)
-        SessionBase.__init__(
+        base.SessionBase.__init__(
             self,
             database_name,
             cluster_name,
@@ -669,8 +371,31 @@ class FrameInSinglePointSession(SessionBase):
         return self._frames
 
 
-class FrameOutSinglePointSession(SessionBase):
+class FrameOutSinglePointSession(base.SessionBase):
+    """Frame Output Single-Point session.
 
+    This session writes frame values for the next transmit. It typically is used
+    for control or simulation applications that require lower level access to
+    frames (not signals).
+
+    This session does not use queues to store frame values. If the write frame
+    function is called twice before the next transmit, the transmitted frame
+    uses the value from the second call to the write frame function.
+
+    The output data is provided as a list of frames, one for each frame
+    specified for the session.
+
+    For this session, NI-XNET transmits each frame according to its properties
+    in the database. Therefore, when you call the write frame function, the
+    number of payload bytes in each frame value must match that frame's Payload
+    Length property. The other frame value elements are ignored, so you can
+    leave them uninitialized. For CAN interfaces, if the number of payload bytes
+    you write is smaller than the Payload Length configured in the database, the
+    requested number of bytes transmit. If the number of payload bytes is larger
+    than the Payload Length configured in the database, the queue is flushed and
+    no frames transmit. For other interfaces, transmitting a number of payload
+    bytes different than the frame payload may cause unexpected results on the bus.
+    """
     def __init__(
             self,
             interface_name,
@@ -706,7 +431,7 @@ class FrameOutSinglePointSession(SessionBase):
             A Frame Output Single-Point session object.
         """
         flattened_list = _utils.flatten_items(frames)
-        SessionBase.__init__(
+        base.SessionBase.__init__(
             self,
             database_name,
             cluster_name,
@@ -720,7 +445,32 @@ class FrameOutSinglePointSession(SessionBase):
         return self._frames
 
 
-class SignalInSinglePointSession(SessionBase):
+class SignalInSinglePointSession(base.SessionBase):
+    """Signal Input Single-Point session.
+
+    This session reads the most recent value received for each signal. It
+    typically is used for control or simulation applications, such as Hardware
+    In the Loop (HIL).
+
+    This session does not use queues to store each received frame. If the
+    interface receives two frames prior to calling
+    :class:`nixnet.signals.SinglePointInSignals.read`, that call to
+    :class:`nixnet.signals.SinglePointInSignals.read` returns signals for the
+    second frame.
+
+    Use :class:`nixnet.signals.SinglePointInSignals.read` for this session.
+
+    You also can specify a trigger signal for a frame. This signal name is
+    :trigger:.<frame name>, and once it is specified in the __init__ 'signals'
+    list, it returns a value of 0.0 if the frame did not arrive since the last
+    Read (or Start), and 1.0 if at least one frame of this ID arrived. You can
+    specify multiple trigger signals for different frames in the same session.
+    For multiplexed signals, a signal may or may not be contained in a received
+    frame. To define a trigger signal for a multiplexed signal, use the signal
+    name :trigger:.<frame name>.<signal name>. This signal returns 1.0 only if a
+    frame with appropriate set multiplexer bit has been received since the last
+    Read or Start.
+    """
 
     def __init__(
             self,
@@ -761,7 +511,7 @@ class SignalInSinglePointSession(SessionBase):
             A Signal Input Single-Point session object.
         """
         flattened_list = _utils.flatten_items(signals)
-        SessionBase.__init__(
+        base.SessionBase.__init__(
             self,
             database_name,
             cluster_name,
@@ -775,7 +525,26 @@ class SignalInSinglePointSession(SessionBase):
         return self._signals
 
 
-class SignalOutSinglePointSession(SessionBase):
+class SignalOutSinglePointSession(base.SessionBase):
+    """Signal Out Single-Point session.
+
+    This session writes signal values for the next frame transmit. It typically
+    is used for control or simulation applications, such as Hardware In the Loop
+    (HIL).
+
+    This session does not use queues to store signal values. If
+    :class:`nixnet.signals.SinglePointOutSignals.write` is called twice before
+    the next transmit, the transmitted frame uses signal values from the second
+    call to :class:`nixnet.signals.SinglePointOutSignals.write`.
+
+    Use :class:`nixnet.signals.SinglePointOutSignals.write` for this session.
+
+    You also can specify a trigger signal for a frame. This signal name is
+    :trigger:.<frame name>, and once it is specified in the __init__ 'signals'
+    list, you can write a value of 0.0 to suppress writing of that frame, or any
+    value not equal to 0.0 to write the frame. You can specify multiple trigger
+    signals for different frames in the same session.
+    """
 
     def __init__(
             self,
@@ -816,7 +585,7 @@ class SignalOutSinglePointSession(SessionBase):
             A Signal Output Single-Point session object.
         """
         flattened_list = _utils.flatten_items(signals)
-        SessionBase.__init__(
+        base.SessionBase.__init__(
             self,
             database_name,
             cluster_name,

--- a/nixnet/session.py
+++ b/nixnet/session.py
@@ -58,7 +58,7 @@ class SessionBase(object):
             database_name,
             cluster_name,
             list,
-            interface,
+            interface_name,
             mode):
         """Create an XNET session at run time using named references to database objects.
 
@@ -78,7 +78,7 @@ class SessionBase(object):
             list: A list of strings describing signals or frames for the session.
                 The list syntax depends on the mode. Refer to mode spefic
                 session classes defined below for 'list' syntax.
-            interface: The XNET Interface to use for this session. If Mode is
+            interface_name: The XNET Interface to use for this session. If Mode is
                 :class:`nixnet.constants.CreateSessionMode.SIGNAL_CONVERSION_SINGLE_POINT`,
                 this input is ignored. You can set it to an empty string.
             mode: The session mode. See :class:`nixnet._enums.CreateSessionMode`.
@@ -87,7 +87,7 @@ class SessionBase(object):
             A Session object.
         """
         self._handle = None  # To satisfy `__del__` in case nx_create_session throws
-        self._handle = _funcs.nx_create_session(database_name, cluster_name, list, interface, mode)
+        self._handle = _funcs.nx_create_session(database_name, cluster_name, list, interface_name, mode)
         self._intf = intf.Interface(self._handle)
         self._j1939 = j1939.J1939(self._handle)
 
@@ -440,7 +440,7 @@ class FrameInStreamSession(SessionBase):
 
     def __init__(
             self,
-            interface,
+            interface_name,
             database_name=':memory:',
             cluster_name=''):
         """Create a Frame Input Stream session.
@@ -449,7 +449,7 @@ class FrameInStreamSession(SessionBase):
         references to database objects.
 
         Args:
-            interface: The XNET Interface to use for this session.
+            interface_name: The XNET Interface to use for this session.
             database_name: The XNET database to use for interface configuration.
                 The database name must use the <alias> or <filepath> syntax
                 (refer to Databases).
@@ -466,7 +466,7 @@ class FrameInStreamSession(SessionBase):
             database_name,
             cluster_name,
             flattened_list,
-            interface,
+            interface_name,
             constants.CreateSessionMode.FRAME_IN_STREAM)
         self._frames = session_frames.InFrames(self._handle)
 
@@ -479,7 +479,7 @@ class FrameOutStreamSession(SessionBase):
 
     def __init__(
             self,
-            interface,
+            interface_name,
             database_name=':memory:',
             cluster_name=''):
         """Create a Frame Input Stream session.
@@ -488,7 +488,7 @@ class FrameOutStreamSession(SessionBase):
         references to database objects.
 
         Args:
-            interface: The XNET Interface to use for this session.
+            interface_name: The XNET Interface to use for this session.
             database_name: The XNET database to use for interface configuration.
                 The database name must use the <alias> or <filepath> syntax
                 (refer to Databases).
@@ -505,7 +505,7 @@ class FrameOutStreamSession(SessionBase):
             database_name,
             cluster_name,
             flattened_list,
-            interface,
+            interface_name,
             constants.CreateSessionMode.FRAME_OUT_STREAM)
         self._frames = session_frames.OutFrames(self._handle)
 
@@ -518,7 +518,7 @@ class FrameInQueuedSession(SessionBase):
 
     def __init__(
             self,
-            interface,
+            interface_name,
             database_name,
             cluster_name,
             frame):
@@ -528,7 +528,7 @@ class FrameInQueuedSession(SessionBase):
         references to database objects.
 
         Args:
-            interface: The XNET Interface to use for this session.
+            interface_name: The XNET Interface to use for this session.
             database_name: The XNET database to use for interface configuration.
                 The database name must use the <alias> or <filepath> syntax
                 (refer to Databases).
@@ -553,7 +553,7 @@ class FrameInQueuedSession(SessionBase):
             database_name,
             cluster_name,
             flattened_list,
-            interface,
+            interface_name,
             constants.CreateSessionMode.FRAME_IN_QUEUED)
         self._frames = session_frames.InFrames(self._handle)
 
@@ -566,7 +566,7 @@ class FrameOutQueuedSession(SessionBase):
 
     def __init__(
             self,
-            interface,
+            interface_name,
             database_name,
             cluster_name,
             frame):
@@ -576,7 +576,7 @@ class FrameOutQueuedSession(SessionBase):
         references to database objects.
 
         Args:
-            interface: The XNET Interface to use for this session.
+            interface_name: The XNET Interface to use for this session.
             database_name: The XNET database to use for interface configuration.
                 The database name must use the <alias> or <filepath> syntax
                 (refer to Databases).
@@ -601,7 +601,7 @@ class FrameOutQueuedSession(SessionBase):
             database_name,
             cluster_name,
             flattened_list,
-            interface,
+            interface_name,
             constants.CreateSessionMode.FRAME_OUT_QUEUED)
         self._frames = session_frames.OutFrames(self._handle)
 
@@ -614,7 +614,7 @@ class FrameInSinglePointSession(SessionBase):
 
     def __init__(
             self,
-            interface,
+            interface_name,
             database_name,
             cluster_name,
             frames):
@@ -624,7 +624,7 @@ class FrameInSinglePointSession(SessionBase):
         references to database objects.
 
         Args:
-            interface: The XNET Interface to use for this session.
+            interface_name: The XNET Interface to use for this session.
             database_name: The XNET database to use for interface configuration.
                 The database name must use the <alias> or <filepath> syntax
                 (refer to Databases).
@@ -651,7 +651,7 @@ class FrameInSinglePointSession(SessionBase):
             database_name,
             cluster_name,
             flattened_list,
-            interface,
+            interface_name,
             constants.CreateSessionMode.FRAME_IN_SINGLE_POINT)
         self._frames = session_frames.SinglePointInFrames(self._handle)
 
@@ -664,7 +664,7 @@ class FrameOutSinglePointSession(SessionBase):
 
     def __init__(
             self,
-            interface,
+            interface_name,
             database_name,
             cluster_name,
             frames):
@@ -674,7 +674,7 @@ class FrameOutSinglePointSession(SessionBase):
         references to database objects.
 
         Args:
-            interface: The XNET Interface to use for this session.
+            interface_name: The XNET Interface to use for this session.
             database_name: The XNET database to use for interface configuration.
                 The database name must use the <alias> or <filepath> syntax
                 (refer to Databases).
@@ -701,7 +701,7 @@ class FrameOutSinglePointSession(SessionBase):
             database_name,
             cluster_name,
             flattened_list,
-            interface,
+            interface_name,
             constants.CreateSessionMode.FRAME_OUT_SINGLE_POINT)
         self._frames = session_frames.SinglePointOutFrames(self._handle)
 
@@ -714,7 +714,7 @@ class SignalInSinglePointSession(SessionBase):
 
     def __init__(
             self,
-            interface,
+            interface_name,
             database_name,
             cluster_name,
             signals):
@@ -724,7 +724,7 @@ class SignalInSinglePointSession(SessionBase):
         references to database objects.
 
         Args:
-            interface: The XNET Interface to use for this session.
+            interface_name: The XNET Interface to use for this session.
             database_name: The XNET database to use for interface configuration.
                 The database name must use the <alias> or <filepath> syntax
                 (refer to Databases).
@@ -755,7 +755,7 @@ class SignalInSinglePointSession(SessionBase):
             database_name,
             cluster_name,
             flattened_list,
-            interface,
+            interface_name,
             constants.CreateSessionMode.SIGNAL_IN_SINGLE_POINT)
         self._signals = session_signals.SinglePointInSignals(self._handle)
 
@@ -768,7 +768,7 @@ class SignalOutSinglePointSession(SessionBase):
 
     def __init__(
             self,
-            interface,
+            interface_name,
             database_name,
             cluster_name,
             signals):
@@ -778,7 +778,7 @@ class SignalOutSinglePointSession(SessionBase):
         references to database objects.
 
         Args:
-            interface: The XNET Interface to use for this session.
+            interface_name: The XNET Interface to use for this session.
             database_name: The XNET database to use for interface configuration.
                 The database name must use the <alias> or <filepath> syntax
                 (refer to Databases).
@@ -809,7 +809,7 @@ class SignalOutSinglePointSession(SessionBase):
             database_name,
             cluster_name,
             flattened_list,
-            interface,
+            interface_name,
             constants.CreateSessionMode.SIGNAL_OUT_SINGLE_POINT)
         self._signals = session_signals.SinglePointOutSignals(self._handle)
 
@@ -820,9 +820,9 @@ class SignalOutSinglePointSession(SessionBase):
 
 def create_session_by_ref(
         database_refs,
-        interface,
+        interface_name,
         mode):
-    return _funcs.nx_create_session_by_ref(database_refs, interface, mode)
+    return _funcs.nx_create_session_by_ref(database_refs, interface_name, mode)
 
 
 def read_signal_waveform(


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nixnet-python/blob/master/CONTRIBUTING.rst).
- [x] New tests have been created for any new features or regression tests for bugfixes.
- [ ] `tox` successfully runs, including unit tests and style checks (see [CONTRIBUTING.md](https://github.com/ni/nixnet-python/blob/master/CONTRIBUTING.rst)).

### What does this Pull Request accomplish?

Adds docstrings for the Session class. The documentation is based off of the C API documentation fouind here: http://zone.ni.com/reference/en-XX/help/372841N-01/TOC63.htm

### Why should this Pull Request be merged?

Provides meaningful documentation for the Session API. We will use this to generate html version of the docs as well.

### What testing has been done?

None
