### PR TITLE
Add Jenkinsfile to root

### DIFF
--- a/Jenkinsfile.txt
+++ b/Jenkinsfile.txt
@@ -1,0 +1,18 @@
+#!groovy
+node('xnetPython01') {
+
+	currentBuild.result = "SUCCESS"
+	
+	try{
+		stage('Test'){
+			// test script to checkout the scm
+			checkout scm
+		}		
+	}
+	
+	catch (err) {
+		currentBuild.result = "FAILURE"
+		throw err
+	}	
+	
+}

--- a/tox.ini
+++ b/tox.ini
@@ -34,7 +34,7 @@ deps =
 description = Verify the package
 commands =
     python setup.py check -m -r -s
-    check-manifest --ignore tox.ini,tests*,.github,.github/*,CONTRIBUTING.rst,docs,docs/*
+    check-manifest --ignore tox.ini,tests*,.github,.github/*,CONTRIBUTING.rst,docs,docs/*,Jenkinsfile.txt
 deps =
     check-manifest
     docutils


### PR DESCRIPTION
Added initial Jenkinsfile to root and updated tox.ini to exclude from Travis CI

- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nixnet-python/blob/master/CONTRIBUTING.rst).
- [ ] New tests have been created for any new features or regression tests for bugfixes.
- [ ] `tox` successfully runs, including unit tests and style checks (see [CONTRIBUTING.md](https://github.com/ni/nixnet-python/blob/master/CONTRIBUTING.rst)).


### What does this Pull Request accomplish?

Adds a generic Jenkinsfile to root so that the Jenkins server can begin testing. Modifies the Tox.ini to exclude the Jenkinsfile.

### Why should this Pull Request be merged?

Part of the CI server setup.

### What testing has been done?

None.
