### PR TITLE
docs(API): Session Frame properties

### DIFF
--- a/nixnet/_session/frames.py
+++ b/nixnet/_session/frames.py
@@ -333,19 +333,108 @@ class Frame(collection.Item):
         return 'Session.Frame(handle={0}, index={0})'.format(self._handle, self._index)
 
     def set_can_start_time_off(self, value):
+        """float: Set CAN Start Time Offset.
+
+        Use this property to configure the amount of time that must elapse
+        between the session being started and the time that the first frame is
+        transmitted across the bus. This is different than the cyclic rate,
+        which determines the time between subsequent frame transmissions.
+
+        Use this property to have more control over the schedule of frames on
+        the bus, to offer more determinism by configuring cyclic frames to be
+        spaced evenly.
+
+        If you do not set this property or you set it to a negative number,
+        NI-XNET chooses this start time offset based on the arbitration
+        identifier and periodic transmit time.
+
+        This property takes effect whenever a session is started. If you stop a
+        session and restart it, the start time offset is re-evaluated.
+        """
         _props.set_session_can_start_time_off(self._handle, self._index, value)
 
     def set_can_tx_time(self, value):
+        """float: Set CAN Transmit Time.
+
+        Use this property to change the frame's transmit time while the session
+        is running. The transmit time is the amount of time that must elapse
+        between subsequent transmissions of a cyclic frame. The default value of
+        this property comes from the database (the XNET Frame CAN Transmit Time
+        property).
+
+        If you set this property while a frame object is currently started, the
+        frame object is stopped, the cyclic rate updated, and then the frame
+        object is restarted. Because of the stopping and starting, the frame's
+        start time offset is re-evaluated.
+
+        The first time a queued frame object is started, the XNET frame's
+        transmit time determines the object's default queue size. Changing this
+        rate has no impact on the queue size. Depending on how you change the
+        rate, the queue may not be sufficient to store data for an extended
+        period of time. You can mitigate this by setting the session Queue Size
+        property to provide sufficient storage for all rates you use. If you are
+        using a single-point session, this is not relevant.
+        """
         _props.set_session_can_tx_time(self._handle, self._index, value)
 
     def set_skip_n_cyclic_frames(self, value):
+        """int: Set Skip N Cyclic Frames
+
+        Note:
+            Only CAN interfaces currently support this property.
+
+        When set to a nonzero value, this property causes the next N cyclic
+        frames to be skipped. When the frame's transmission time arrives and the
+        skip count is nonzero, a frame value is dequeued (if this is not a
+        single-point session), and the skip count is decremented, but the frame
+        actually is not transmitted across the bus. When the skip count
+        decrements to zero, subsequent cyclic transmissions resume. This
+        property is valid only for output sessions and frames with cyclic timing
+        (that is, not event-based frames).
+
+        This property is useful for testing of ECU behavior when a cyclic frame
+        is expected, but is missing for N cycles.
+        """
         _props.set_session_skip_n_cyclic_frames(self._handle, self._index, value)
 
     def set_output_queue_update_freq(self, value):
         _props.set_session_output_queue_update_freq(self._handle, self._index, value)
 
     def set_lin_tx_n_corrupted_chksums(self, value):
+        """int: Set LIN Transmit N Corrupted Checksums.
+
+        When set to a nonzero value, this property causes the next N number of
+        checksums to be corrupted. The checksum is corrupted by negating the
+        value calculated per the database; (EnhancedValue * -1) or
+        (ClassicValue * -1). This property is valid only for output sessions. If
+        the frame is transmitted in an unconditional or sporadic schedule slot,
+        N is always decremented for each frame transmission. If the frame is
+        transmitted in an event-triggered slot and a collision occurs, N is not
+        decremented. In that case, N is decremented only when the collision
+        resolving schedule is executed and the frame is successfully transmitted.
+        If the frame is the only one to transmit in the event-triggered slot
+        (no collision), N is decremented at event-triggered slot time.
+
+        This property is useful for testing ECU behavior when a corrupted
+        checksum is transmitted.
+        """
         _props.set_session_lin_tx_n_corrupted_chksums(self._handle, self._index, value)
 
     def set_j1939_addr_filter(self, value):
+        """str: Set J1939 Address Filter.
+
+        You can use this property in input sessions only. It defines a filter
+        for the source address of the PGN transmitting node. You can use it when
+        multiple nodes with different addresses are transmitting the same PGN.
+
+        If the filter is active, the session accepts only frames transmitted by
+        a node with the defined address. All other frames with the same PGN but
+        transmitted by other nodes are ignored.
+
+        The value is a string representing the decimal value of the address.
+        If your address is given as an integer value, you must convert it to a
+        string value (for example, with str(value)).
+
+        To reset the filter, set the value to empty string (default).
+        """
         _props.set_session_j1939_addr_filter(self._handle, self._index, value)


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nixnet-python/blob/master/CONTRIBUTING.rst).
- [x] New tests have been created for any new features or regression tests for bugfixes.
- [x] `tox` successfully runs, including unit tests and style checks (see [CONTRIBUTING.md](https://github.com/ni/nixnet-python/blob/master/CONTRIBUTING.rst)).
