### PR TITLE
fix(API): Correct spelling of Err.PORT_LEDS_BUSY

### DIFF
--- a/nixnet/_enums.py
+++ b/nixnet/_enums.py
@@ -369,7 +369,7 @@ class Err(enum.Enum):
     # You tried to blink the port LEDs but these are currently busy. Solution:
     # stop all applications running on that port; do not access it from MAX or LV
     # Project.
-    PORT_LE_DS_BUSY = _cconsts.NX_ERR_PORT_LE_DS_BUSY
+    PORT_LEDS_BUSY = _cconsts.NX_ERR_PORT_LE_DS_BUSY
     # You tried to set a FlexRay keyslot ID that is not listed as valid in the
     # database. Solution: only pass slot IDs of frames that have the startup or
     # sync property set in the database.

--- a/tests/test_system.py
+++ b/tests/test_system.py
@@ -127,7 +127,7 @@ def test_intf_blink(nixnet_in_interface):
             input_session.start()
             with pytest.raises(errors.XnetError) as excinfo:
                 in_intf.blink(constants.BlinkMode.ENABLE)
-            assert excinfo.value.error_type == constants.Err.PORT_LE_DS_BUSY
+            assert excinfo.value.error_type == constants.Err.PORT_LEDS_BUSY
             in_intf.blink(constants.BlinkMode.DISABLE)
         in_intf.blink(constants.BlinkMode.ENABLE)
         in_intf.blink(constants.BlinkMode.DISABLE)


### PR DESCRIPTION
Fixes #104

BREAKING CHANGE: Renamed Err.PORT_LE_DS_BUSY to Err.PORT_LEDS_BUSY

- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nixnet-python/blob/master/CONTRIBUTING.rst).
- [x] New tests have been created for any new features or regression tests for bugfixes.
- [x] `tox` successfully runs, including unit tests and style checks (see [CONTRIBUTING.md](https://github.com/ni/nixnet-python/blob/master/CONTRIBUTING.rst)).