### PR TITLE
tests: Report code coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .cache/
 .tox/
 __pycache__
+.coverage
 *.egg-info/
 *.pyc

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,12 @@ python:
 install:
   - pip install --upgrade setuptools
   - pip install -U tox-travis
+  - pip install -U coveralls
 
 script:
   - tox
   # Verify the file is at least valid even if it isn't run.
   - tox -c tox-integration.ini -l
+
+after_success:
+  - coveralls

--- a/tox-integration.ini
+++ b/tox-integration.ini
@@ -12,9 +12,11 @@ commands = pytest {posargs: --nixnet-in-interface {env:NIXNET_FIXTURE_IN_INTERFA
 deps =
     pytest
     mock
+    pytest-cov
+    coverage
 passenv =
     NIXNET_FIXTURE_IN_INTERFACE
     NIXNET_FIXTURE_OUT_INTERFACE
 
 [pytest]
-addopts = --verbose --doctest-modules --ignore=setup.py
+addopts = --cov nixnet --cov nixnet_examples --verbose --doctest-modules --ignore=setup.py

--- a/tox.ini
+++ b/tox.ini
@@ -13,6 +13,8 @@ commands =
 deps =
     pytest
     mock
+    pytest-cov
+    coverage
 
 [testenv:flake8]
 description = Run static analysis
@@ -56,7 +58,7 @@ exclude = build,docs,.tox,__pycache__
 ignore = H903
 
 [pytest]
-addopts = --verbose --doctest-modules --ignore=setup.py
+addopts = --cov nixnet --cov nixnet_examples --verbose --doctest-modules --ignore=setup.py
 
 [travis]
 python =


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nixnet-python/blob/master/CONTRIBUTING.rst).
- [x] New tests have been created for any new features or regression tests for bugfixes.
- [x] `tox` successfully runs, including unit tests and style checks (see [CONTRIBUTING.md](https://github.com/ni/nixnet-python/blob/master/CONTRIBUTING.rst)).