### PR TITLE
fix(CI): Only run tests under test environments

### DIFF
--- a/tox-integration.ini
+++ b/tox-integration.ini
@@ -8,7 +8,8 @@ skip_missing_interpreters=True
 
 [testenv]
 description = Run tests
-commands = pytest {posargs: --nixnet-in-interface {env:NIXNET_FIXTURE_IN_INTERFACE:CAN1} --nixnet-out-interface {env:NIXNET_FIXTURE_OUT_INTERFACE:CAN2}}
+commands =
+    test: pytest {posargs: --nixnet-in-interface {env:NIXNET_FIXTURE_IN_INTERFACE:CAN1} --nixnet-out-interface {env:NIXNET_FIXTURE_OUT_INTERFACE:CAN2}}
 deps =
     pytest
     mock


### PR DESCRIPTION
So the hacks pile up.  We have a separate file to avoid running the tests
on TravisCI.  We need all the main environments listed in this separate
file so we can do syntax checks on it (because of how tox-travis works).
The problem is that then caused our tests to be run under all of those
environments on Jenkins but the dependencies weren't installed.

So limiting the test run to the test environment seems to make everything
happy.

- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nixnet-python/blob/master/CONTRIBUTING.rst).
- [x] New tests have been created for any new features or regression tests for bugfixes.
- [x] `tox` successfully runs, including unit tests and style checks (see [CONTRIBUTING.md](https://github.com/ni/nixnet-python/blob/master/CONTRIBUTING.rst)).