### PR TITLE
feat(CI): Email reports

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -34,5 +34,6 @@ node('xnetPython') {
 	}
 	catch (err) {
 		currentBuild.result = "FAILURE"
+		emailextrecipients([[$class: 'CulpritsRecipientProvider'], [$class: 'DevelopersRecipientProvider'], [$class: 'RequesterRecipientProvider']])
 	}
 }


### PR DESCRIPTION
Since we don't have a Jenkins badge on the front page, it might be
difficult to track when builds have failed besides our immediate PR, like
with master.  So emailing relevant people.

- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nixnet-python/blob/master/CONTRIBUTING.rst).
- [x] New tests have been created for any new features or regression tests for bugfixes.
- [x] `tox` successfully runs, including unit tests and style checks (see [CONTRIBUTING.md](https://github.com/ni/nixnet-python/blob/master/CONTRIBUTING.rst)).