### PR TITLE
docs: Clean up documentation

### DIFF
--- a/nixnet/_session/base.py
+++ b/nixnet/_session/base.py
@@ -152,9 +152,9 @@ class SessionBase(object):
         Default Value properties.
 
         Args:
-            scope: Describes the impact of this operation on the underlying
-                state models for the session and its interface.
-                See :any:`nixnet._enums.StartStopScope`.
+            scope(:any:`nixnet._enums.StartStopScope`): Describes the impact of
+                this operation on the underlying state models for the session
+                and its interface.
         """
         _funcs.nx_start(self._handle, scope)
 
@@ -181,9 +181,9 @@ class SessionBase(object):
         to State Models.
 
         Args:
-            scope: Describes the impact of this operation on the underlying
-                state models for the session and its interface.
-                See :any:`nixnet._enums.StartStopScope`.
+            scope(:any:`nixnet._enums.StartStopScope`): Describes the impact of
+                this operation on the underlying state models for the session
+                and its interface.
         """
         _funcs.nx_stop(self._handle, scope)
 
@@ -230,8 +230,7 @@ class SessionBase(object):
         based, and the state is Boolean (true/false).
 
         Args:
-            timeout: A float representing the maximum amount of time to wait in
-                seconds.
+            timeout(float): The maximum amount of time to wait in seconds.
         """
         _funcs.nx_wait(self._handle, constants.Condition.TRANSMIT_COMPLETE, 0, timeout)
 
@@ -254,8 +253,7 @@ class SessionBase(object):
             communication (invalid time of 0 prior)
 
         Args:
-            timeout: A float representing the maximum amount of time to wait in
-                seconds.
+            timeout(float): The maximum amount of time to wait in seconds.
         """
         _funcs.nx_wait(self._handle, constants.Condition.INTF_COMMUNICATING, 0, timeout)
 
@@ -277,8 +275,7 @@ class SessionBase(object):
         detects that remote wakeup.
 
         Args:
-            timeout: A float representing the maximum amount of time to wait in
-                seconds.
+            timeout(float): The maximum amount of time to wait in seconds.
         """
         _funcs.nx_wait(self._handle, constants.Condition.INTF_REMOTE_WAKEUP, 0, timeout)
 
@@ -298,8 +295,8 @@ class SessionBase(object):
         pair is an internal and the other an external.
 
         Args:
-            source: A string representing the connection source name.
-            destination: A string representing the connection destination name.
+            source(str): Connection source name.
+            destination(str): Connection destination name.
         """
         _funcs.nx_connect_terminals(self._handle, source, destination)
 
@@ -328,8 +325,8 @@ class SessionBase(object):
         Attempting to disconnect a nonconnected terminal results in an error.
 
         Args:
-            source: A string representing the connection source name.
-            destination: A string representing the connection destination name.
+            source(str): Connection source name.
+            destination(str): Connection destination name.
         """
         _funcs.nx_disconnect_terminals(self._handle, source, destination)
 

--- a/nixnet/_session/frames.py
+++ b/nixnet/_session/frames.py
@@ -60,10 +60,9 @@ class InFrames(Frames):
         The raw bytes encode one or more frames using the Raw Frame Format.
 
         Args:
-            number_of_bytes_to_read: An integer repesenting the number of bytes to read.
-            timeout: The time to wait for number to read frame bytes to become
-                available; the 'timeout' is represented as 64-bit floating-point
-                in units of seconds.
+            number_of_bytes_to_read(int): The number of bytes to read.
+            timeout(float): The time in seconds to wait for number to read
+                frame bytes to become available.
 
                 To avoid returning a partial frame, even when
                 'number_of_bytes_to_read' are available from the hardware, this
@@ -104,11 +103,10 @@ class InFrames(Frames):
         """Read raw CAN frames.
 
         Args:
-            number_to_read: An integer repesenting the number of raw CAN frames
+            number_to_read(int): Number of raw CAN frames
                 to read.
-            timeout: The time to wait for number to read frames to become
-                available; the 'timeout' is represented as 64-bit floating-point
-                in units of seconds.
+            timeout(float): The time in seconds to wait for number to read
+                frame bytes to become available.
 
                 If 'timeout' is positive, this function waits for
                 'number_to_read' frames to be received, then
@@ -140,10 +138,9 @@ class InFrames(Frames):
         """Read :any:`nixnet.types.CanFrame` data.
 
         Args:
-            number_to_read: An integer repesenting the number of CAN frames to read.
-            timeout: The time to wait for number to read frames to become
-                available; the 'timeout' is represented as 64-bit floating-point
-                in units of seconds.
+            number_to_read(int): Number of CAN frames to read.
+            timeout(float): The time in seconds to wait for number to read
+                frame bytes to become available.
 
                 If 'timeout' is positive, this function waits for
                 'number_to_read' frames to be received, then
@@ -176,10 +173,10 @@ class SinglePointInFrames(Frames):
         """Read data as a list of raw bytes (frame data).
 
         Args:
-            number_of_bytes_to_read: An integer repesenting the number of bytes to read.
+            number_of_bytes_to_read(int): Number of bytes to read.
 
         Returns:
-            A list of raw bytes representing the data.
+            bytes: Raw bytes representing the data.
         """
         buffer, number_of_bytes_returned = _funcs.nx_read_frame(
             self._handle,
@@ -229,9 +226,9 @@ class OutFrames(Frames):
         The raw bytes encode one or more frames using the Raw Frame Format.
 
         Args:
-            frame_bytes: List of bytes, representing frames to transmit.
-            timeout: The time to wait for the data to be queued up for transmit.
-                The 'timeout' is represented as 64-bit floating-point in units of seconds.
+            frame_bytes(bytes): Frames to transmit.
+            timeout(float): The time in seconds to wait for number to read
+                frame bytes to become available.
 
                 If 'timeout' is positive, this function waits up to that 'timeout'
                 for space to become available in queues. If the space is not
@@ -256,10 +253,10 @@ class OutFrames(Frames):
         """Write raw CAN frame data.
 
         Args:
-            raw_frames: One or more :any:`nixnet.types.RawFrame` objects to be
+            raw_frames(list): One or more :any:`nixnet.types.RawFrame` objects to be
                 written to the session.
-            timeout: The time to wait for the data to be queued up for transmit.
-                The 'timeout' is represented as 64-bit floating-point in units of seconds.
+            timeout(float): The time in seconds to wait for number to read
+                frame bytes to become available.
 
                 If 'timeout' is positive, this function waits up to that 'timeout'
                 for space to become available in queues. If the space is not
@@ -288,10 +285,10 @@ class OutFrames(Frames):
         """Write CAN frame data.
 
         Args:
-            can_frames: One or more :any:`nixnet.types.CanFrame` objects to be
+            can_frames(list): One or more :any:`nixnet.types.CanFrame` objects to be
                 written to the session.
-            timeout: The time to wait for the data to be queued up for transmit.
-                The 'timeout' is represented as 64-bit floating-point in units of seconds.
+            timeout(float): The time in seconds to wait for number to read
+                frame bytes to become available.
 
                 If 'timeout' is positive, this function waits up to that 'timeout'
                 for space to become available in queues. If the space is not
@@ -325,7 +322,7 @@ class SinglePointOutFrames(Frames):
         The raw bytes encode one or more frames using the Raw Frame Format.
 
         Args:
-            frame_bytes: List of bytes, representing frames to transmit.
+            frame_bytes(bytes): Frames to transmit.
         """
         _funcs.nx_write_frame(self._handle, bytes(frame_bytes), constants.TIMEOUT_NONE)
 
@@ -336,7 +333,7 @@ class SinglePointOutFrames(Frames):
         """Write raw CAN frame data.
 
         Args:
-            raw_frames: A list of :any:`nixnet.types.RawFrame` objects to be
+            raw_frames(list): One or more :any:`nixnet.types.RawFrame` objects to be
                 written to the session.
         """
         units = itertools.chain.from_iterable(
@@ -352,7 +349,7 @@ class SinglePointOutFrames(Frames):
         """Write CAN frame data.
 
         Args:
-            can_frames: A list of :any:`nixnet.types.CanFrame` objects to be
+            can_frames(list): One or more :any:`nixnet.types.CanFrame` objects to be
                 written to the session.
         """
         raw_frames = (frame.to_raw() for frame in can_frames)
@@ -365,39 +362,35 @@ class Frame(collection.Item):
     def __repr__(self):
         return 'Session.Frame(handle={0}, index={0})'.format(self._handle, self._index)
 
-    def set_can_start_time_off(self, value):
+    def set_can_start_time_off(self, offset):
         # type: (float) -> None
-        """float: Set CAN Start Time Offset.
+        """Set CAN Start Time Offset.
 
-        Use this property to configure the amount of time that must elapse
-        between the session being started and the time that the first frame is
-        transmitted across the bus. This is different than the cyclic rate,
-        which determines the time between subsequent frame transmissions.
-
-        Use this property to have more control over the schedule of frames on
+        Use this function to have more control over the schedule of frames on
         the bus, to offer more determinism by configuring cyclic frames to be
         spaced evenly.
 
-        If you do not set this property or you set it to a negative number,
+        If you do not call this function or you set it to a negative number,
         NI-XNET chooses this start time offset based on the arbitration
         identifier and periodic transmit time.
 
-        This property takes effect whenever a session is started. If you stop a
+        ``offset`` takes effect whenever a session is started. If you stop a
         session and restart it, the start time offset is re-evaluated.
+
+        Args:
+            offset(float): The amount of time that must elapse between the
+                session being started and the time that the first frame is
+                transmitted across the bus. This is different than the cyclic
+                rate, which determines the time between subsequent frame
+                transmissions.
         """
-        _props.set_session_can_start_time_off(self._handle, self._index, value)
+        _props.set_session_can_start_time_off(self._handle, self._index, offset)
 
-    def set_can_tx_time(self, value):
+    def set_can_tx_time(self, time):
         # type: (float) -> None
-        """float: Set CAN Transmit Time.
+        """Set CAN Transmit Time.
 
-        Use this property to change the frame's transmit time while the session
-        is running. The transmit time is the amount of time that must elapse
-        between subsequent transmissions of a cyclic frame. The default value of
-        this property comes from the database (the XNET Frame CAN Transmit Time
-        property).
-
-        If you set this property while a frame object is currently started, the
+        If you call this function while a frame object is currently started, the
         frame object is stopped, the cyclic rate updated, and then the frame
         object is restarted. Because of the stopping and starting, the frame's
         start time offset is re-evaluated.
@@ -409,67 +402,83 @@ class Frame(collection.Item):
         period of time. You can mitigate this by setting the session Queue Size
         property to provide sufficient storage for all rates you use. If you are
         using a single-point session, this is not relevant.
+
+        Args:
+            time(float): Frame's transmit time while the session is running.
+                The transmit time is the amount of time that must elapse
+                between subsequent transmissions of a cyclic frame. The default
+                value of this property comes from the database (the XNET Frame
+                CAN Transmit Time property).
         """
-        _props.set_session_can_tx_time(self._handle, self._index, value)
+        _props.set_session_can_tx_time(self._handle, self._index, time)
 
-    def set_skip_n_cyclic_frames(self, value):
+    def set_skip_n_cyclic_frames(self, n):
         # type: (int) -> None
-        """int: Set Skip N Cyclic Frames
+        """Set Skip N Cyclic Frames
 
-        Note:
-            Only CAN interfaces currently support this property.
+        When the frame's transmission time arrives and the skip count is
+        nonzero, a frame value is dequeued (if this is not a single-point
+        session), and the skip count is decremented, but the frame actually is
+        not transmitted across the bus. When the skip count decrements to zero,
+        subsequent cyclic transmissions resume.
 
-        When set to a nonzero value, this property causes the next N cyclic
-        frames to be skipped. When the frame's transmission time arrives and the
-        skip count is nonzero, a frame value is dequeued (if this is not a
-        single-point session), and the skip count is decremented, but the frame
-        actually is not transmitted across the bus. When the skip count
-        decrements to zero, subsequent cyclic transmissions resume. This
-        property is valid only for output sessions and frames with cyclic timing
-        (that is, not event-based frames).
-
-        This property is useful for testing of ECU behavior when a cyclic frame
+        This function is useful for testing of ECU behavior when a cyclic frame
         is expected, but is missing for N cycles.
+
+        .. note: Only CAN interfaces currently support this function.
+
+        .. note: This property is valid only for output sessions and frames
+            with cyclic timing (that is, not event-based frames).
+
+        Args:
+            n(int): Skip the next N cyclic frames when nonzero.
         """
-        _props.set_session_skip_n_cyclic_frames(self._handle, self._index, value)
+        _props.set_session_skip_n_cyclic_frames(self._handle, self._index, n)
 
-    def set_lin_tx_n_corrupted_chksums(self, value):
+    def set_lin_tx_n_corrupted_chksums(self, n):
         # type: (int) -> None
-        """int: Set LIN Transmit N Corrupted Checksums.
+        """Set LIN Transmit N Corrupted Checksums.
 
-        When set to a nonzero value, this property causes the next N number of
+        When set to a nonzero value, this function causes the next N number of
         checksums to be corrupted. The checksum is corrupted by negating the
         value calculated per the database; (EnhancedValue * -1) or
-        (ClassicValue * -1). This property is valid only for output sessions. If
-        the frame is transmitted in an unconditional or sporadic schedule slot,
-        N is always decremented for each frame transmission. If the frame is
-        transmitted in an event-triggered slot and a collision occurs, N is not
-        decremented. In that case, N is decremented only when the collision
-        resolving schedule is executed and the frame is successfully transmitted.
-        If the frame is the only one to transmit in the event-triggered slot
-        (no collision), N is decremented at event-triggered slot time.
+        (ClassicValue * -1).
 
-        This property is useful for testing ECU behavior when a corrupted
+        If the frame is transmitted in an unconditional or sporadic schedule
+        slot, N is always decremented for each frame transmission. If the frame
+        is transmitted in an event-triggered slot and a collision occurs, N is
+        not decremented. In that case, N is decremented only when the collision
+        resolving schedule is executed and the frame is successfully
+        transmitted.  If the frame is the only one to transmit in the
+        event-triggered slot (no collision), N is decremented at
+        event-triggered slot time.
+
+        This function is useful for testing ECU behavior when a corrupted
         checksum is transmitted.
+
+        .. note: This function is valid only for output sessions.
+
+        Args:
+            n(int): Number of checksums to be corrupted.
         """
-        _props.set_session_lin_tx_n_corrupted_chksums(self._handle, self._index, value)
+        _props.set_session_lin_tx_n_corrupted_chksums(self._handle, self._index, n)
 
-    def set_j1939_addr_filter(self, value):
-        # type: (typing.Text) -> None
-        """str: Set J1939 Address Filter.
+    def set_j1939_addr_filter(self, address=""):
+        # type: (typing.Union[typing.Text, int]) -> None
+        """Set J1939 Address Filter.
 
-        You can use this property in input sessions only. It defines a filter
-        for the source address of the PGN transmitting node. You can use it when
-        multiple nodes with different addresses are transmitting the same PGN.
+        Define a filter for the source address of the PGN transmitting node.
+        You can use it when multiple nodes with different addresses are
+        transmitting the same PGN.
 
         If the filter is active, the session accepts only frames transmitted by
         a node with the defined address. All other frames with the same PGN but
         transmitted by other nodes are ignored.
 
-        The value is a string representing the decimal value of the address.
-        If your address is given as an integer value, you must convert it to a
-        string value (for example, with str(value)).
+        .. note: You can use this function in input sessions only.
 
-        To reset the filter, set the value to empty string (default).
+        Args:
+            address(str or int): Decimal value of the address. Leave blank to
+                reset the filter.
         """
-        _props.set_session_j1939_addr_filter(self._handle, self._index, value)
+        _props.set_session_j1939_addr_filter(self._handle, self._index, str(address))

--- a/nixnet/_session/intf.py
+++ b/nixnet/_session/intf.py
@@ -214,7 +214,11 @@ class Interface(object):
 
     def set_can_ext_tcvr_config(self, value):
         # type: (int) -> None
-        '''int: Configure XS series CAN hardware to communicate properly with your external transceiver.'''
+        ''': Configure XS series CAN hardware to communicate properly with your external transceiver.
+
+        Args:
+            value(int): Bitfield
+        '''
         _props.set_session_intf_can_ext_tcvr_config(self._handle, value)
 
     @property

--- a/nixnet/_session/signals.py
+++ b/nixnet/_session/signals.py
@@ -45,8 +45,7 @@ class SinglePointInSignals(Signals):
         """Read data from a Signal Input Single-Point session.
 
         Yields:
-            A tuple of timestamp (internal NI-XNET ctype around u64) and signal
-            values (float).
+            A tuple of timestamp (int) and signal values (float).
         """
         num_signals = len(self)
         timestamps, values = _funcs.nx_read_signal_single_point(self._handle, num_signals)
@@ -67,7 +66,7 @@ class SinglePointOutSignals(Signals):
         """Write data to a Signal Output Single-Point session.
 
         Args:
-            value_buffer: A list of singal values (float).
+            value_buffer(list): A list of singal values (float).
         """
         _funcs.nx_write_signal_single_point(self._handle, list(value_buffer))
 

--- a/nixnet/errors.py
+++ b/nixnet/errors.py
@@ -26,8 +26,8 @@ class XnetError(Error):
         """Initialize error.
 
         Args:
-            message: A string specifing the error message.
-            error_code: An integer specifing the NI-XNET error code.
+            message(str): Error message.
+            error_code(int): NI-XNET error code.
         """
         super(XnetError, self).__init__(message)
 
@@ -41,21 +41,13 @@ class XnetError(Error):
     @property
     def error_code(self):
         # type: (...) -> int
-        """Error code reported by NI-XNET.
-
-        Returns:
-            An integer specifing the NI-XNET error code.
-        """
+        """int: Error code reported by NI-XNET."""
         return self._error_code
 
     @property
     def error_type(self):
         # type: (...) -> _enums.Err
-        """Error enum reported by NI-XNET.
-
-        Returns:
-            A :any:`nixnet._enums.Err` specifing the NI-XNET error type.
-        """
+        """:any:`nixnet._enums.Err`: Error type reported by NI-XNET."""
         return self._error_type
 
 
@@ -64,44 +56,36 @@ class XnetWarning(Warning):
     def __init__(
         self,
         message,  # type: typing.Text
-        error_code,  # type: int
+        warning_code,  # type: int
     ):
         # type: (...) -> None
         """Initialize warning.
 
         Args:
-            message: A string specifing the warning message.
-            error_code: An integer specifing the NI-DAQmx error code.
+            message(str): Warning message.
+            warning_code(int): NI-XNET warning code.
         """
         super(XnetWarning, self).__init__(
-            'Warning {0} occurred.\n\n{1}'.format(error_code, message))
+            'Warning {0} occurred.\n\n{1}'.format(warning_code, message))
 
-        self._error_code = error_code
+        self._warning_code = warning_code
 
         try:
-            self._error_type = _enums.Warn(self._error_code)
+            self._warning_type = _enums.Warn(self._warning_code)
         except ValueError:
-            self._error_type = None
+            self._warning_type = None
 
     @property
-    def error_code(self):
+    def warning_code(self):
         # type: (...) -> int
-        """Error code reported by NI-XNET.
-
-        Returns:
-            An integer specifing the NI-XNET error code.
-        """
-        return self._error_code
+        """int: Warning code reported by NI-XNET."""
+        return self._warning_code
 
     @property
-    def error_type(self):
+    def warning_type(self):
         # type: (...) -> _enums.Warn
-        """Warning enum reported by NI-XNET.
-
-        Returns:
-            A :any:`nixnet._enums.Warn` specifiing the NI-XNET warning type.
-        """
-        return self._error_type
+        """:any:`nixnet._enums.Warn`: Warning type reported by NI-XNET."""
+        return self._warning_type
 
 
 class _ResourceWarning(Warning):

--- a/nixnet/session.py
+++ b/nixnet/session.py
@@ -67,17 +67,14 @@ class FrameInStreamSession(base.SessionBase):
         references to database objects.
 
         Args:
-            interface_name: A string representing the XNET Interface to use for
+            interface_name(str): XNET Interface name to use for
                 this session.
-            database_name: A string representing the XNET database to use for
+            database_name(str): XNET database name to use for
                 interface configuration. The database name must use the <alias>
                 or <filepath> syntax (refer to Databases).
-            cluster_name: A string representing the XNET cluster to use for
+            cluster_name(str): XNET cluster name to use for
                 interface configuration. The name must specify a cluster from
                 the database given in the database_name parameter.
-
-        Returns:
-            A Frame Input Stream session object.
         """
         flattened_list = _utils.flatten_items(None)
         base.SessionBase.__init__(
@@ -92,6 +89,7 @@ class FrameInStreamSession(base.SessionBase):
     @property
     def frames(self):
         # type: () -> session_frames.InFrames
+        """:any:`nixnet._session.frames.InFrames`: Operate on session's frames"""
         return self._frames
 
 
@@ -147,17 +145,14 @@ class FrameOutStreamSession(base.SessionBase):
         references to database objects.
 
         Args:
-            interface_name: A string representing the XNET Interface to use for
+            interface_name(str): XNET Interface name to use for
                 this session.
-            database_name: A string representing the XNET database to use for
+            database_name(str): XNET database name to use for
                 interface configuration. The database name must use the <alias>
                 or <filepath> syntax (refer to Databases).
-            cluster_name: A string representing the XNET cluster to use for
+            cluster_name(str): XNET cluster name to use for
                 interface configuration. The name must specify a cluster from
                 the database given in the database_name parameter.
-
-        Returns:
-            A Frame Output Stream session object.
         """
         flattened_list = _utils.flatten_items(None)
         base.SessionBase.__init__(
@@ -172,6 +167,7 @@ class FrameOutStreamSession(base.SessionBase):
     @property
     def frames(self):
         # type: () -> session_frames.OutFrames
+        """:any:`nixnet._session.frames.InFrames`: Operate on session's frames"""
         return self._frames
 
 
@@ -205,26 +201,23 @@ class FrameInQueuedSession(base.SessionBase):
         references to database objects.
 
         Args:
-            interface_name: A string representing the XNET Interface to use for
+            interface_name(str): XNET Interface name to use for
                 this session.
-            database_name: A string representing the XNET database to use for
+            database_name(str): XNET database name to use for
                 interface configuration. The database name must use the <alias>
-                or <filepath> syntax(refer to Databases).
-            cluster_name: A string representing the XNET cluster to use for
+                or <filepath> syntax (refer to Databases).
+            cluster_name(str): XNET cluster name to use for
                 interface configuration. The name must specify a cluster from
                 the database given in the database_name parameter. If it is left
-                blank, the cluster is extracted from the 'frame' parameter.
-            frame: A string describing one XNET Frame or PDU name. This name
+                blank, the cluster is extracted from the ``frame`` parameter.
+            frame(str): XNET Frame or PDU name. This name
                 must be one of the following options, whichever uniquely
                 identifies a frame within the database given:
 
-                    -<Frame>
-                    -<Cluster>.<Frame>
-                    -<PDU>
-                    -<Cluster>.<PDU>
-
-        Returns:
-            A Frame Input Queued session object.
+                    - ``<Frame>``
+                    - ``<Cluster>.<Frame>``
+                    - ``<PDU>``
+                    - ``<Cluster>.<PDU>``
         """
         flattened_list = _utils.flatten_items(frame)
         base.SessionBase.__init__(
@@ -239,6 +232,7 @@ class FrameInQueuedSession(base.SessionBase):
     @property
     def frames(self):
         # type: () -> session_frames.InFrames
+        """:any:`nixnet._session.frames.InFrames`: Operate on session's frames"""
         return self._frames
 
 
@@ -285,26 +279,23 @@ class FrameOutQueuedSession(base.SessionBase):
         references to database objects.
 
         Args:
-            interface_name: A string representing the XNET Interface to use for
+            interface_name(str): XNET Interface name to use for
                 this session.
-            database_name: A string representing the XNET database to use for
+            database_name(str): XNET database name to use for
                 interface configuration. The database name must use the <alias>
                 or <filepath> syntax (refer to Databases).
-            cluster_name: A string representing the XNET cluster to use for
+            cluster_name(str): XNET cluster name to use for
                 interface configuration. The name must specify a cluster from
                 the database given in the database_name parameter. If it is left
-                blank, the cluster is extracted from the 'frame' parameter.
-            frame: A string describing one XNET Frame or PDU name. This name
+                blank, the cluster is extracted from the ``frame`` parameter.
+            frame(str): XNET Frame or PDU name. This name
                 must be one of the following options, whichever uniquely
                 identifies a frame within the database given:
 
-                    -<Frame>
-                    -<Cluster>.<Frame>
-                    -<PDU>
-                    -<Cluster>.<PDU>
-
-        Returns:
-            A Frame Output Queued session object.
+                    - ``<Frame>``
+                    - ``<Cluster>.<Frame>``
+                    - ``<PDU>``
+                    - ``<Cluster>.<PDU>``
         """
         flattened_list = _utils.flatten_items(frame)
         base.SessionBase.__init__(
@@ -319,6 +310,7 @@ class FrameOutQueuedSession(base.SessionBase):
     @property
     def frames(self):
         # type: () -> session_frames.OutFrames
+        """:any:`nixnet._session.frames.InFrames`: Operate on session's frames"""
         return self._frames
 
 
@@ -351,29 +343,26 @@ class FrameInSinglePointSession(base.SessionBase):
         references to database objects.
 
         Args:
-            interface_name: A string representing the XNET Interface to use for
+            interface_name(str): XNET Interface name to use for
                 this session.
-            database_name: A string representing the XNET database to use for
+            database_name(str): XNET database name to use for
                 interface configuration. The database name must use the <alias>
                 or <filepath> syntax (refer to Databases).
-            cluster_name: A string representing the XNET cluster to use for
+            cluster_name(str): XNET cluster name to use for
                 interface configuration. The name must specify a cluster from
                 the database given in the database_name parameter. If it is left
-                blank, the cluster is extracted from the 'frames' parameter.
-            frames: A list of strings describing frames for the session. The
+                blank, the cluster is extracted from the ``frames`` parameter.
+            frames(list): Strings describing frames for the session. The
                 list syntax is as follows:
 
-                    List contains one or more XNET Frame or PDU names. Each name
-                    must be one of the following options, whichever uniquely
-                    identifies a frame within the database given:
+                List contains one or more XNET Frame or PDU names. Each name
+                must be one of the following options, whichever uniquely
+                identifies a frame within the database given:
 
-                        -<Frame>
-                        -<Cluster>.<Frame>
-                        -<PDU>
-                        -<Cluster>.<PDU>
-
-        Returns:
-            A Frame Input Single-Point session object.
+                    - ``<Frame>``
+                    - ``<Cluster>.<Frame>``
+                    - ``<PDU>``
+                    - ``<Cluster>.<PDU>``
         """
         flattened_list = _utils.flatten_items(frames)
         base.SessionBase.__init__(
@@ -388,6 +377,7 @@ class FrameInSinglePointSession(base.SessionBase):
     @property
     def frames(self):
         # type: () -> session_frames.SinglePointInFrames
+        """:any:`nixnet._session.frames.InFrames`: Operate on session's frames"""
         return self._frames
 
 
@@ -430,29 +420,26 @@ class FrameOutSinglePointSession(base.SessionBase):
         references to database objects.
 
         Args:
-            interface_name: A string representing the XNET Interface to use for
+            interface_name(str): XNET Interface name to use for
                 this session.
-            database_name: A string representing the XNET database to use for
+            database_name(str): XNET database name to use for
                 interface configuration. The database name must use the <alias>
                 or <filepath> syntax (refer to Databases).
-            cluster_name: A string representing the XNET cluster to use for
+            cluster_name(str): XNET cluster name to use for
                 interface configuration. The name must specify a cluster from
                 the database given in the database_name parameter. If it is left
-                blank, the cluster is extracted from the 'frames' parameter.
-            frames: A list of strings describing frames for the session. The
+                blank, the cluster is extracted from the ``frames`` parameter.
+            frames(list): Strings describing frames for the session. The
                 list syntax is as follows:
 
-                    List contains one or more XNET Frame or PDU names. Each name
-                    must be one of the following options, whichever uniquely
-                    identifies a frame within the database given:
+                List contains one or more XNET Frame or PDU names. Each name
+                must be one of the following options, whichever uniquely
+                identifies a frame within the database given:
 
-                        -<Frame>
-                        -<Cluster>.<Frame>
-                        -<PDU>
-                        -<Cluster>.<PDU>
-
-        Returns:
-            A Frame Output Single-Point session object.
+                    - ``<Frame>``
+                    - ``<Cluster>.<Frame>``
+                    - ``<PDU>``
+                    - ``<Cluster>.<PDU>``
         """
         flattened_list = _utils.flatten_items(frames)
         base.SessionBase.__init__(
@@ -467,6 +454,7 @@ class FrameOutSinglePointSession(base.SessionBase):
     @property
     def frames(self):
         # type: () -> session_frames.SinglePointOutFrames
+        """:any:`nixnet._session.frames.InFrames`: Operate on session's frames"""
         return self._frames
 
 
@@ -486,7 +474,7 @@ class SignalInSinglePointSession(base.SessionBase):
     Use :any:`nixnet._session.signals.SinglePointInSignals.read` for this session.
 
     You also can specify a trigger signal for a frame. This signal name is
-    :trigger:.<frame name>, and once it is specified in the __init__ 'signals'
+    :trigger:.<frame name>, and once it is specified in the __init__ ``signals``
     list, it returns a value of 0.0 if the frame did not arrive since the last
     Read (or Start), and 1.0 if at least one frame of this ID arrived. You can
     specify multiple trigger signals for different frames in the same session.
@@ -511,34 +499,31 @@ class SignalInSinglePointSession(base.SessionBase):
         references to database objects.
 
         Args:
-            interface_name: A string representing the XNET Interface to use for
+            interface_name(str): XNET Interface name to use for
                 this session.
-            database_name: A string representing the XNET database to use for
+            database_name(str): XNET database name to use for
                 interface configuration. The database name must use the <alias>
                 or <filepath> syntax (refer to Databases).
-            cluster_name: A string representing the XNET cluster to use for
+            cluster_name(str): XNET cluster name to use for
                 interface configuration. The name must specify a cluster from
                 the database given in the database_name parameter. If it is left
-                blank, the cluster is extracted from the signals parameter.
-            signals: A list of strings describing signals for the session. The
+                blank, the cluster is extracted from the ``signals`` parameter.
+            signals(list): Strings describing signals for the session. The
                 list syntax is as follows:
 
-                    List contains one or more XNET Signal names. Each name must
-                    be one of the following options, whichever uniquely
-                    identifies a signal within the database given:
+                ``signals`` contains one or more XNET Signal names. Each name must
+                be one of the following options, whichever uniquely
+                identifies a signal within the database given:
 
-                        -<Signal>
-                        -<Frame>.<Signal>
-                        -<Cluster>.<Frame>.<Signal>
-                        -<PDU>.<Signal>
-                        -<Cluster>.<PDU>.<Signal>
+                    - ``<Signal>``
+                    - ``<Frame>.<Signal>``
+                    - ``<Cluster>.<Frame>.<Signal>``
+                    - ``<PDU>.<Signal>``
+                    - ``<Cluster>.<PDU>.<Signal>``
 
-                    List may also contain one or more trigger signals. For
-                    information about trigger signals, refer to Signal Output
-                    Single-Point Mode or Signal Input Single-Point Mode.
-
-        Returns:
-            A Signal Input Single-Point session object.
+                ``signals`` may also contain one or more trigger signals. For
+                information about trigger signals, refer to Signal Output
+                Single-Point Mode or Signal Input Single-Point Mode.
         """
         flattened_list = _utils.flatten_items(signals)
         base.SessionBase.__init__(
@@ -553,6 +538,7 @@ class SignalInSinglePointSession(base.SessionBase):
     @property
     def signals(self):
         # type: () -> session_signals.SinglePointInSignals
+        """:any:`nixnet._session.signals.SinglePointInSignals`: Operate on session's signals"""
         return self._signals
 
 
@@ -571,7 +557,7 @@ class SignalOutSinglePointSession(base.SessionBase):
     Use :any:`nixnet._session.signals.SinglePointOutSignals.write` for this session.
 
     You also can specify a trigger signal for a frame. This signal name is
-    :trigger:.<frame name>, and once it is specified in the __init__ 'signals'
+    :trigger:.<frame name>, and once it is specified in the __init__ ``signals``
     list, you can write a value of 0.0 to suppress writing of that frame, or any
     value not equal to 0.0 to write the frame. You can specify multiple trigger
     signals for different frames in the same session.
@@ -591,34 +577,31 @@ class SignalOutSinglePointSession(base.SessionBase):
         references to database objects.
 
         Args:
-            interface_name: A string representing the XNET Interface to use for
+            interface_name(str): XNET Interface name to use for
                 this session.
-            database_name: A string representing the XNET database to use for
+            database_name(str): XNET database name to use for
                 interface configuration. The database name must use the <alias>
                 or <filepath> syntax (refer to Databases).
-            cluster_name: A string representing the XNET cluster to use for
+            cluster_name(str): XNET cluster name to use for
                 interface configuration. The name must specify a cluster from
                 the database given in the database_name parameter. If it is left
-                blank, the cluster is extracted from the signals parameter.
-            signals: A list of strings describing signals for the session. The
+                blank, the cluster is extracted from the ``signals`` parameter.
+            signals(list): Strings describing signals for the session. The
                 list syntax is as follows:
 
-                    List contains one or more XNET Signal names. Each name must
-                    be one of the following options, whichever uniquely
-                    identifies a signal within the database given:
+                ``signals`` contains one or more XNET Signal names. Each name must
+                be one of the following options, whichever uniquely
+                identifies a signal within the database given:
 
-                        -<Signal>
-                        -<Frame>.<Signal>
-                        -<Cluster>.<Frame>.<Signal>
-                        -<PDU>.<Signal>
-                        -<Cluster>.<PDU>.<Signal>
+                    - ``<Signal>``
+                    - ``<Frame>.<Signal>``
+                    - ``<Cluster>.<Frame>.<Signal>``
+                    - ``<PDU>.<Signal>``
+                    - ``<Cluster>.<PDU>.<Signal>``
 
-                    List may also contain one or more trigger signals. For
-                    information about trigger signals, refer to Signal Output
-                    Single-Point Mode or Signal Output Single-Point Mode.
-
-        Returns:
-            A Signal Output Single-Point session object.
+                ``signals`` may also contain one or more trigger signals. For
+                information about trigger signals, refer to Signal Output
+                Single-Point Mode or Signal Output Single-Point Mode.
         """
         flattened_list = _utils.flatten_items(signals)
         base.SessionBase.__init__(
@@ -633,6 +616,7 @@ class SignalOutSinglePointSession(base.SessionBase):
     @property
     def signals(self):
         # type: () -> session_signals.SinglePointOutSignals
+        """:any:`nixnet._session.signals.SinglePointInSignals`: Operate on session's signals"""
         return self._signals
 
 

--- a/nixnet/types.py
+++ b/nixnet/types.py
@@ -66,12 +66,12 @@ class RawFrame(object):
     """Raw Frame.
 
     Attributes:
-        timestamp: Absolute time the XNET interface received the end-of-frame.
-        identifier: An integer repersenting the CAN frame arbitration identifier.
-        type: Frame type as described in :any:`nixnet._enums.FrameType`.
-        flags: An integer repersenting flags that qualify the type.
-        info: An integer repersenting info that qualify the type.
-        payload: A byte string representing the payload.
+        timestamp(int): Absolute time the XNET interface received the end-of-frame.
+        identifier(int): CAN frame arbitration identifier.
+        type(:any:`nixnet._enums.FrameType`): Frame type.
+        flags(int): Flags that qualify the type.
+        info(int): Info that qualify the type.
+        payload(bytes): Payload.
     """
 
     __slots__ = [
@@ -125,13 +125,13 @@ class CanFrame(object):
     """CAN Frame.
 
     Attributes:
-        identifier: An integer representing the CAN frame arbitration identifier.
-        extended: A boolean indicating if the identifier uses an extended format.
-        echo: A boolean indicating if the frame is an echo of a successful
+        identifier(int): CAN frame arbitration identifier.
+        extended(bool): If the identifier uses an extended format.
+        echo(bool): If the frame is an echo of a successful
             transmit rather than being received from the network.
-        type: Frame type as described in :any:`nixnet._enums.FrameType`.
-        timestamp: Absolute time the XNET interface received the end-of-frame.
-        payload: A byte string representing the payload.
+        type(:any:`nixnet._enums.FrameType`): Frame type.
+        timestamp(int): Absolute time the XNET interface received the end-of-frame.
+        payload(bytes): Payload.
     """
 
     __slots__ = [

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -49,23 +49,23 @@ def test_known_warning():
     with pytest.warns(errors.XnetWarning) as record:
         _errors.check_for_error(_enums.Warn.DATABASE_IMPORT.value)
     assert len(record) == 1
-    assert record[0].message.error_code == _enums.Warn.DATABASE_IMPORT.value
-    assert record[0].message.error_type == _enums.Warn.DATABASE_IMPORT
+    assert record[0].message.warning_code == _enums.Warn.DATABASE_IMPORT.value
+    assert record[0].message.warning_type == _enums.Warn.DATABASE_IMPORT
     assert record[0].message.args == ('Warning 1073098885 occurred.\n\n', )
 
 
 @mock.patch('nixnet._cfuncs.lib', MockXnetLibrary)
 def test_unknown_warning():
-    error_code = 201232  # Arbitrary number
+    warning_code = 201232  # Arbitrary number
     # Ensure it is an unknown error
     with pytest.raises(ValueError):
-        _enums.Warn(error_code)
+        _enums.Warn(warning_code)
 
     with pytest.warns(errors.XnetWarning) as record:
-        _errors.check_for_error(error_code)
+        _errors.check_for_error(warning_code)
     assert len(record) == 1
-    assert record[0].message.error_code == error_code
-    assert record[0].message.error_type is None
+    assert record[0].message.warning_code == warning_code
+    assert record[0].message.warning_type is None
     assert record[0].message.args == ('Warning 201232 occurred.\n\n', )
 
 


### PR DESCRIPTION
- Fix property documentation that was in function form
- Add parameter types
- Rename setter parameters to be more context aware
- Default `set_j1939_addr_filter` to reflect `reset` in documentation
- Allow `set_j1939_addr_filter` to also take an `int` to simplify
  documentation.
- Corrected Warning member variables to not mention errors

BREAKING CHANGE

`Frame` set function parameter names have changed.  If keyword arguments
are used, they will need to be updated.

`XnetWarning`'s `error_code` and `error_type` have been renamed to
`warning_code` and `warning_type`.

- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nixnet-python/blob/master/CONTRIBUTING.rst).
- [x] New tests have been created for any new features or regression tests for bugfixes.
- [x] `tox` successfully runs, including unit tests and style checks (see [CONTRIBUTING.md](https://github.com/ni/nixnet-python/blob/master/CONTRIBUTING.rst)).