### PR TITLE
feat(API): Simplify read/write calls

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -35,7 +35,7 @@ Author       National Instruments
    >>>     input_session.intf.can_term = constants.CanTerm.ON
    >>>     input_session.intf.baud_rate = 125000
 
-   >>>     frames = input_session.frames.read_can(count)
+   >>>     frames = input_session.frames.read(count)
    >>>     for frame in frames:
    >>>         print('Received frame:')
    >>>         print(frame)

--- a/nixnet/_py2.py
+++ b/nixnet/_py2.py
@@ -1,0 +1,17 @@
+﻿from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+
+class abstractclassmethod(classmethod):  # NOQA: N801
+    """Backport from Python 3.2
+
+    Once we are only on Python 3.3+, `abstractmethod` should be sufficient.
+    """
+
+    __slots__ = ()
+    __isabstractmethod__ = True
+
+    def __init__(self, callable):
+        callable.__isabstractmethod__ = True
+        super(abstractclassmethod, self).__init__(callable)

--- a/nixnet_examples/can_frame_queued_io.py
+++ b/nixnet_examples/can_frame_queued_io.py
@@ -66,7 +66,7 @@ def main():
                     payload[index] = byte + i
 
                 frame.payload = payload
-                output_session.frames.write_can([frame])
+                output_session.frames.write([frame])
                 print('Sent frame with ID %s payload: %s' % (id, payload))
 
                 # Wait 1 s and then read the received values.
@@ -74,7 +74,7 @@ def main():
                 time.sleep(1)
 
                 count = 1
-                frames = input_session.frames.read_can(count)
+                frames = input_session.frames.read(count)
                 for frame in frames:
                     print('Received frame: ')
                     pp.pprint(frame)

--- a/nixnet_examples/can_frame_stream_io.py
+++ b/nixnet_examples/can_frame_stream_io.py
@@ -58,7 +58,7 @@ def main():
                     payload[index] = byte + i
 
                 frame.payload = payload
-                output_session.frames.write_can([frame])
+                output_session.frames.write([frame])
                 print('Sent frame with ID %s payload: %s' % (id, payload))
 
                 # Wait 1 s and then read the received values.
@@ -66,7 +66,7 @@ def main():
                 time.sleep(1)
 
                 count = 1
-                frames = input_session.frames.read_can(count)
+                frames = input_session.frames.read(count)
                 for frame in frames:
                     print('Received frame: ')
                     pp.pprint(frame)

--- a/tests/test_frames.py
+++ b/tests/test_frames.py
@@ -101,13 +101,13 @@ def test_stream_loopback(nixnet_in_interface, nixnet_out_interface):
             payload_list = [2, 4, 8, 16]
             expected_frames = [
                 types.CanFrame(0, False, constants.FrameType.CAN_DATA, bytes(bytearray(payload_list)))]
-            output_session.frames.write_can(expected_frames)
+            output_session.frames.write(expected_frames)
 
             # Wait 1 s and then read the received values.
             # They should be the same as the ones sent.
             time.sleep(1)
 
-            actual_frames = list(input_session.frames.read_can(1))
+            actual_frames = list(input_session.frames.read(1))
             assert len(expected_frames) == len(actual_frames)
             for i, (expected, actual) in enumerate(zip(expected_frames, actual_frames)):
                 assert_can_frame(i, expected, actual)
@@ -136,13 +136,13 @@ def test_queued_loopback(nixnet_in_interface, nixnet_out_interface):
             payload_list = [2, 4, 8, 16]
             expected_frames = [
                 types.CanFrame(66, False, constants.FrameType.CAN_DATA, bytes(bytearray(payload_list)))]
-            output_session.frames.write_can(expected_frames)
+            output_session.frames.write(expected_frames)
 
             # Wait 1 s and then read the received values.
             # They should be the same as the ones sent.
             time.sleep(1)
 
-            actual_frames = list(input_session.frames.read_can(1))
+            actual_frames = list(input_session.frames.read(1))
             assert len(expected_frames) == len(actual_frames)
             for i, (expected, actual) in enumerate(zip(expected_frames, actual_frames)):
                 assert_can_frame(i, expected, actual)
@@ -173,13 +173,13 @@ def test_singlepoint_loopback(nixnet_in_interface, nixnet_out_interface):
             expected_frames = [
                 types.CanFrame(66, False, constants.FrameType.CAN_DATA, bytes(bytearray(first_payload_list))),
                 types.CanFrame(67, False, constants.FrameType.CAN_DATA, bytes(bytearray(second_payload_list)))]
-            output_session.frames.write_can(expected_frames)
+            output_session.frames.write(expected_frames)
 
             # Wait 1 s and then read the received values.
             # They should be the same as the ones sent.
             time.sleep(1)
 
-            actual_frames = list(input_session.frames.read_can())
+            actual_frames = list(input_session.frames.read())
             assert len(expected_frames) == len(actual_frames)
             for i, (expected, actual) in enumerate(zip(expected_frames, actual_frames)):
                 assert_can_frame(i, expected, actual)


### PR DESCRIPTION
nixnet will now automatically adapt Frame `read`/`write` calls based on
the data being transfered rather than requiring per-frame-type read/write
calls (like `read_can`/`write_can`).

This will help when adding special frame types.  Without this change, they
would have been interpreted as `CanFrame` which would provide weird
results unless someone thought to check `frame.type` and then they'd have
to go through hoops to get it into the correct frame object to interpret
it correctly.

This lowers the visibility of `read_raw`/`write_raw` in the API which
should only be used for some specific advanced cases anyways (arbitrary
data logging).

BREAKING CHANGE:

`read_can` has been replaced by `read`.  If the session reads non-CAN
frames (see special frame types), then those will be included in returned
data but will not be misinterpreted.

`read_raw` has been replaced by `read(..., frame_type=types.RawFrame)`.

`write_can` and `write_frame` have been replaced by `write`.

- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nixnet-python/blob/master/CONTRIBUTING.rst).
- [x] New tests have been created for any new features or regression tests for bugfixes.
- [x] `tox` successfully runs, including unit tests and style checks (see [CONTRIBUTING.md](https://github.com/ni/nixnet-python/blob/master/CONTRIBUTING.rst)).