### PR TITLE
feat(API): Provide can ID parser for `out_strm_list_by_id`

### DIFF
--- a/nixnet/_session/intf.py
+++ b/nixnet/_session/intf.py
@@ -158,15 +158,13 @@ class Interface(object):
         in that it provides a list of frames for replay filtering. This
         property provides an alternate format for you to specify the frames by
         their CAN arbitration ID or LIN unprotected ID. The property's data
-        type is an array of unsigned 32-bit integer (U32). Each integer
-        represents a CAN or LIN frame's identifier, using the same encoding as
-        the Raw Frame Format.
+        type is an array of integers. Each integer represents a CAN or LIN
+        frame's identifier, using the same encoding as :any:`nixnet.types.RawFrame`.
 
-        Within each CAN frame ID value, bit 29 (hex 20000000) indicates the CAN
-        identifier format (set for extended, clear for standard). If bit 29 is
-        clear, the lower 11 bits (0-10) contain the CAN frame identifier. If
-        bit 29 is set, the lower 29 bits (0-28) contain the CAN frame
-        identifier. LIN frame ID values may be within the range of possible LIN
+        For CAN Frames, see :any:`nixnet.types.CanIdentifier` for parsing and
+        generating raw identifiers.
+
+        LIN frame ID values may be within the range of possible LIN
         IDs (0-63).
 
         See also :any:`Interface.out_strm_list`.

--- a/nixnet_examples/can_frame_queued_io.py
+++ b/nixnet_examples/can_frame_queued_io.py
@@ -55,10 +55,9 @@ def main():
                 payload_list = [2, 4, 8, 16]
                 print('Unrecognized input ({}). Setting data buffer to {}', user_value, payload_list)
 
-            id = 0
-            extended = False
+            id = types.CanIdentifier(0)
             payload = bytearray(payload_list)
-            frame = types.CanFrame(id, extended, constants.FrameType.CAN_DATA, payload)
+            frame = types.CanFrame(id, constants.FrameType.CAN_DATA, payload)
 
             i = 0
             while True:

--- a/nixnet_examples/can_frame_stream_io.py
+++ b/nixnet_examples/can_frame_stream_io.py
@@ -46,10 +46,9 @@ def main():
                 payload_list = [2, 4, 8, 16]
                 print('Unrecognized input ({}). Setting data buffer to {}', user_value, payload_list)
 
-            id = 0
-            extended = False
+            id = types.CanIdentifier(0)
             payload = bytearray(payload_list)
-            frame = types.CanFrame(id, extended, constants.FrameType.CAN_DATA, payload)
+            frame = types.CanFrame(id, constants.FrameType.CAN_DATA, payload)
 
             print('The same values should be received. Press q to quit')
             i = 0

--- a/tests/test_frames.py
+++ b/tests/test_frames.py
@@ -99,7 +99,7 @@ def test_stream_loopback(nixnet_in_interface, nixnet_out_interface):
 
             payload_list = [2, 4, 8, 16]
             expected_frames = [
-                types.CanFrame(0, False, constants.FrameType.CAN_DATA, bytes(bytearray(payload_list)))]
+                types.CanFrame(0, constants.FrameType.CAN_DATA, bytes(bytearray(payload_list)))]
             output_session.frames.write(expected_frames)
 
             # Wait 1 s and then read the received values.
@@ -134,7 +134,7 @@ def test_queued_loopback(nixnet_in_interface, nixnet_out_interface):
 
             payload_list = [2, 4, 8, 16]
             expected_frames = [
-                types.CanFrame(66, False, constants.FrameType.CAN_DATA, bytes(bytearray(payload_list)))]
+                types.CanFrame(66, constants.FrameType.CAN_DATA, bytes(bytearray(payload_list)))]
             output_session.frames.write(expected_frames)
 
             # Wait 1 s and then read the received values.
@@ -170,8 +170,8 @@ def test_singlepoint_loopback(nixnet_in_interface, nixnet_out_interface):
             first_payload_list = [2, 4, 8, 16]
             second_payload_list = [1, 3]
             expected_frames = [
-                types.CanFrame(66, False, constants.FrameType.CAN_DATA, bytes(bytearray(first_payload_list))),
-                types.CanFrame(67, False, constants.FrameType.CAN_DATA, bytes(bytearray(second_payload_list)))]
+                types.CanFrame(66, constants.FrameType.CAN_DATA, bytes(bytearray(first_payload_list))),
+                types.CanFrame(67, constants.FrameType.CAN_DATA, bytes(bytearray(second_payload_list)))]
             output_session.frames.write(expected_frames)
 
             # Wait 1 s and then read the received values.

--- a/tests/test_frames.py
+++ b/tests/test_frames.py
@@ -79,7 +79,6 @@ def test_serialize_frame_with_base_payload():
 
 def assert_can_frame(index, sent, received):
     assert sent.identifier == received.identifier
-    assert sent.extended == received.extended
     assert sent.echo == received.echo
     assert sent.type == received.type
     assert sent.payload == received.payload


### PR DESCRIPTION
`out_strm_list_by_id` might contain either LIN or CAN frames IDs without a
way to distinguish them so we can't completely abstract it like we did for
IDs in the actual Frames.  Instead the parsing logic from `CanFrame` was
extracted and abstracted so it can be reused with this property
(`CanIdentifier`).

Fixes #115

BREAKING CHANGE: `CanFrame` now accepts a single `CanIdentifier` rather
than an `(int, bool)`.  An `int` can still be passed in as a short-form
and will be interpreted as a non-extended id.

- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nixnet-python/blob/master/CONTRIBUTING.rst).
- [x] New tests have been created for any new features or regression tests for bugfixes.
- [x] `tox` successfully runs, including unit tests and style checks (see [CONTRIBUTING.md](https://github.com/ni/nixnet-python/blob/master/CONTRIBUTING.rst)).