### PR TITLE
tests: Expand coverage

### DIFF
--- a/nixnet/_ctypedefs.py
+++ b/nixnet/_ctypedefs.py
@@ -27,19 +27,11 @@ class bool8(ctypes.c_ubyte):  # NOQA: N801
 
     BYTES = 1
 
-    @classmethod
-    def from_param(cls, param):
-        return ctypes.c_ubyte(1) if bool(param) else ctypes.c_ubyte(0)
-
 
 class bool32(ctypes.c_uint):  # NOQA: N801
     """32-bit boolean C-type."""
 
     BYTES = 4
-
-    @classmethod
-    def from_param(cls, param):
-        return ctypes.c_uint(1) if bool(param) else ctypes.c_uint(0)
 
 
 class byte(ctypes.c_char):  # NOQA: N801

--- a/tests/test_frames.py
+++ b/tests/test_frames.py
@@ -99,7 +99,7 @@ def test_can_identifier_overflow():
 @mock.patch('nixnet._errors.check_for_error', raise_code)
 def test_can_identifier_extended_overflow():
     with pytest.raises(errors.XnetError):
-        int(types.CanIdentifier(0xFFFFFFFF))
+        int(types.CanIdentifier(0xFFFFFFFF, True))
 
 
 def test_raw_frame_equality():

--- a/tests/test_frames.py
+++ b/tests/test_frames.py
@@ -81,11 +81,13 @@ def test_can_identifier_equality():
     assert types.CanIdentifier(130, True) == types.CanIdentifier(130, True)
     assert not (types.CanIdentifier(130) == types.CanIdentifier(13))
     assert not (types.CanIdentifier(130) == types.CanIdentifier(130, True))
+    assert not (types.CanIdentifier(130) == "<invalid>")
 
     assert not (types.CanIdentifier(130) != types.CanIdentifier(130))
     assert not (types.CanIdentifier(130, True) != types.CanIdentifier(130, True))
     assert types.CanIdentifier(130) != types.CanIdentifier(13)
     assert types.CanIdentifier(130) != types.CanIdentifier(130, True)
+    assert types.CanIdentifier(130) != "<invalid>"
 
 
 @mock.patch('nixnet._errors.check_for_error', raise_code)

--- a/tests/test_session_intf.py
+++ b/tests/test_session_intf.py
@@ -45,7 +45,7 @@ def test_intf_container(nixnet_in_interface):
 
         assert str(input_session.intf) == nixnet_in_interface
 
-        print(input_session.intf)
+        print(repr(input_session.intf))
 
 
 @pytest.mark.integration


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nixnet-python/blob/master/CONTRIBUTING.rst).
- [x] New tests have been created for any new features or regression tests for bugfixes.
- [x] `tox` successfully runs, including unit tests and style checks (see [CONTRIBUTING.md](https://github.com/ni/nixnet-python/blob/master/CONTRIBUTING.rst)).