### PR TITLE
tests(Session): Expand coverage

### DIFF
--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -3,6 +3,7 @@ from __future__ import division
 from __future__ import print_function
 
 import mock  # type: ignore
+import time
 
 import pytest  # type: ignore
 
@@ -150,3 +151,52 @@ def test_parse_can_comm_bitfield():
         last_err=constants.CanLastErr.CRC,
         tx_err_count=255,
         rx_err_count=255)
+
+
+def assert_can_frame(index, sent, received):
+    assert sent.identifier == received.identifier
+    assert sent.echo == received.echo
+    assert sent.type == received.type
+    assert sent.payload == received.payload
+
+    assert sent.timestamp != received.timestamp
+
+
+@pytest.mark.integration
+def test_start_explicit(nixnet_in_interface, nixnet_out_interface):
+    """Demonstrate that data is properly sent out on an explicit start.
+
+    Assumes test_frames.test_queued_loopback works
+    """
+    database_name = 'NIXNET_example'
+    cluster_name = 'CAN_Cluster'
+    frame_name = 'CANEventFrame1'
+
+    with nixnet.FrameInQueuedSession(
+            nixnet_in_interface,
+            database_name,
+            cluster_name,
+            frame_name) as input_session:
+        with nixnet.FrameOutQueuedSession(
+                nixnet_out_interface,
+                database_name,
+                cluster_name,
+                frame_name) as output_session:
+            output_session.auto_start = False
+            # Start the input session manually to make sure that the first
+            # frame value sent before the initial read will be received.
+            input_session.start()
+
+            expected_frames = [
+                types.CanFrame(66, constants.FrameType.CAN_DATA, b'\x01\x02\x03\x04')]
+            output_session.frames.write(expected_frames)
+
+            output_session.start()
+            # Wait 1 s and then read the received values.
+            # They should be the same as the ones sent.
+            time.sleep(1)
+
+            actual_frames = list(input_session.frames.read(1))
+            assert len(expected_frames) == len(actual_frames)
+            for i, (expected, actual) in enumerate(zip(expected_frames, actual_frames)):
+                assert_can_frame(i, expected, actual)


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nixnet-python/blob/master/CONTRIBUTING.rst).
- [x] New tests have been created for any new features or regression tests for bugfixes.
- [x] `tox` successfully runs, including unit tests and style checks (see [CONTRIBUTING.md](https://github.com/ni/nixnet-python/blob/master/CONTRIBUTING.rst)).