### PR TITLE
fix(API): Frame ID validation to support 11 bit (not 10)

### DIFF
--- a/nixnet/types.py
+++ b/nixnet/types.py
@@ -300,7 +300,7 @@ class CanFrame(Frame):
         "timestamp",
         "payload"]
 
-    _FRAME_ID_MASK = 0x000003FF
+    _FRAME_ID_MASK = 0x000007FF
     _EXTENDED_FRAME_ID_MASK = 0x1FFFFFFF
 
     def __init__(self, identifier, type, payload=b""):


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nixnet-python/blob/master/CONTRIBUTING.rst).
- [x] New tests have been created for any new features or regression tests for bugfixes.
- [x] `tox` successfully runs, including unit tests and style checks (see [CONTRIBUTING.md](https://github.com/ni/nixnet-python/blob/master/CONTRIBUTING.rst)).