### PR TITLE
docs: Re-organize documentation tree

### DIFF
--- a/docs/base.rst
+++ b/docs/base.rst
@@ -1,5 +1,5 @@
 nixnet.session.base
-====================
+===================
 
 .. automodule:: nixnet._session.base
     :members:

--- a/docs/collection.rst
+++ b/docs/collection.rst
@@ -1,7 +1,0 @@
-nixnet.collection
-=================
-
-.. automodule:: nixnet._session.collection
-    :members:
-    :show-inheritance:
-    :special-members:

--- a/docs/constants.rst
+++ b/docs/constants.rst
@@ -1,0 +1,10 @@
+nixnet.constants
+================
+
+.. automodule:: nixnet.constants
+    :members:
+    :show-inheritance:
+
+.. automodule:: nixnet._enums
+    :members:
+    :show-inheritance:

--- a/docs/enums.rst
+++ b/docs/enums.rst
@@ -1,6 +1,0 @@
-nixnet.enums
-============
-
-.. automodule:: nixnet._enums
-    :members:
-    :show-inheritance:

--- a/docs/errors.rst
+++ b/docs/errors.rst
@@ -4,4 +4,3 @@ nixnet.errors
 .. automodule:: nixnet.errors
     :members:
     :show-inheritance:
-    :special-members:

--- a/docs/frames.rst
+++ b/docs/frames.rst
@@ -1,5 +1,5 @@
-nixnet.frames
-=============
+nixnet.session.frames
+=====================
 
 .. automodule:: nixnet._session.frames
     :members:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -13,16 +13,9 @@ NI-XNET Python Documentation
    :caption: API Reference:
 
    session
-   frames
-   signals
-   intf
-   j1939
+   constants
    types
    errors
-
-   base
-   enums
-   collection
 
 
 Indices and Tables

--- a/docs/intf.rst
+++ b/docs/intf.rst
@@ -4,4 +4,3 @@ nixnet.session.intf
 .. automodule:: nixnet._session.intf
     :members:
     :show-inheritance:
-    :special-members:

--- a/docs/intf.rst
+++ b/docs/intf.rst
@@ -1,5 +1,5 @@
-nixnet.intf
-===========
+nixnet.session.intf
+===================
 
 .. automodule:: nixnet._session.intf
     :members:

--- a/docs/j1939.rst
+++ b/docs/j1939.rst
@@ -4,4 +4,3 @@ nixnet.session.j1939
 .. automodule:: nixnet._session.j1939
     :members:
     :show-inheritance:
-    :special-members:

--- a/docs/j1939.rst
+++ b/docs/j1939.rst
@@ -1,5 +1,5 @@
-nixnet.j1939
-============
+nixnet.session.j1939
+====================
 
 .. automodule:: nixnet._session.j1939
     :members:

--- a/docs/session.rst
+++ b/docs/session.rst
@@ -6,3 +6,14 @@ nixnet.session
     :show-inheritance:
     :special-members:
     :inherited-members:
+
+.. toctree::
+   :maxdepth: 3
+   :caption: API Reference:
+
+   frames
+   signals
+   intf
+   j1939
+
+   base

--- a/docs/session.rst
+++ b/docs/session.rst
@@ -4,7 +4,6 @@ nixnet.session
 .. automodule:: nixnet.session
     :members:
     :show-inheritance:
-    :special-members:
     :inherited-members:
 
 .. toctree::

--- a/docs/signals.rst
+++ b/docs/signals.rst
@@ -1,5 +1,5 @@
-nixnet.signals
-==============
+nixnet.session.signals
+======================
 
 .. automodule:: nixnet._session.signals
     :members:

--- a/docs/types.rst
+++ b/docs/types.rst
@@ -4,4 +4,3 @@ nixnet.types
 .. automodule:: nixnet.types
     :members:
     :show-inheritance:
-    :special-members:

--- a/nixnet/_session/frames.py
+++ b/nixnet/_session/frames.py
@@ -355,9 +355,9 @@ class Frame(collection.Item):
         This function is useful for testing of ECU behavior when a cyclic frame
         is expected, but is missing for N cycles.
 
-        .. note: Only CAN interfaces currently support this function.
+        .. note:: Only CAN interfaces currently support this function.
 
-        .. note: This property is valid only for output sessions and frames
+        .. note:: This property is valid only for output sessions and frames
             with cyclic timing (that is, not event-based frames).
 
         Args:
@@ -386,7 +386,7 @@ class Frame(collection.Item):
         This function is useful for testing ECU behavior when a corrupted
         checksum is transmitted.
 
-        .. note: This function is valid only for output sessions.
+        .. note:: This function is valid only for output sessions.
 
         Args:
             n(int): Number of checksums to be corrupted.
@@ -405,7 +405,7 @@ class Frame(collection.Item):
         a node with the defined address. All other frames with the same PGN but
         transmitted by other nodes are ignored.
 
-        .. note: You can use this function in input sessions only.
+        .. note:: You can use this function in input sessions only.
 
         Args:
             address(str or int): Decimal value of the address. Leave blank to

--- a/nixnet/_session/intf.py
+++ b/nixnet/_session/intf.py
@@ -135,7 +135,7 @@ class Interface(object):
         CAN arbitration IDs or LIN unprotected IDs, you can use
         Interface:Output Stream List By ID instead of this property.
 
-        :: note: Only CAN and LIN interfaces currently support this property.
+        .. note:: Only CAN and LIN interfaces currently support this property.
         '''
         for ref in _props.get_session_intf_out_strm_list(self._handle):
             yield _frame.Frame(ref)
@@ -187,7 +187,7 @@ class Interface(object):
 
         See also :any:`Interface.out_strm_list`.
 
-        .. note: Only CAN and LIN interfaces currently support this property.
+        .. note:: Only CAN and LIN interfaces currently support this property.
         '''
         return constants.OutStrmTimng(_props.get_session_intf_out_strm_timng(self._handle))
 
@@ -255,9 +255,9 @@ class Interface(object):
         transmit at the same time. NI-XNET stores the frames in an internal
         queue and transmits them onto the CAN bus when the bus is idle.
 
-        .. note: You can modify this property only when the interface is
+        .. note:: You can modify this property only when the interface is
            stopped.
-        .. note: Setting this property causes the internal queue to be flushed.
+        .. note:: Setting this property causes the internal queue to be flushed.
            If you start a session, queue frames, and then stop the session and
            change this mode, some frames may be lost. Set this property to the
            desired value once; do not constantly change modes.
@@ -287,9 +287,9 @@ class Interface(object):
         frame is not transmitted successfully, no further transmissions are
         attempted.
 
-        .. note: You can modify this property only when the interface is
+        .. note:: You can modify this property only when the interface is
            stopped.
-        .. note: Setting this property causes the internal queue to be flushed.
+        .. note:: Setting this property causes the internal queue to be flushed.
            If you start a session, queue frames, and then stop the session and
            change this mode, some frames may be lost. Set this property to the
            desired value once; do not constantly change modes.
@@ -312,9 +312,9 @@ class Interface(object):
         different termination requirements, and the Off and On values have
         different meanings, see :any:`nixnet._enums.CanTerm`.
 
-        .. note: You can modify this property only when the interface is
+        .. note:: You can modify this property only when the interface is
            stopped.
-        .. note: This property does not take effect until the interface is
+        .. note:: This property does not take effect until the interface is
            started.
         '''
         return constants.CanTerm(_props.get_session_intf_can_term(self._handle))
@@ -418,13 +418,13 @@ class Interface(object):
         The Transmit I/O mode may not exceed the mode set by the XNET Cluster
         CAN:I/O Mode property.
 
-        .. note: This property is not supported in CAN FD+BRS ISO mode. If you
+        .. note:: This property is not supported in CAN FD+BRS ISO mode. If you
            are using ISO CAN FD mode, you define the transmit I/O mode in the
            database with the I/O Mode property of the frame. (When a database
            is not used (for example, in frame stream mode), define the transmit
            I/O mode with the frame type field of the frame data.) Note that ISO
            CAN FD mode is the default mode for CAN FD in NI-XNET.
-        .. note: This property affects only the transmission of frames. Even if
+        .. note:: This property affects only the transmission of frames. Even if
            you set the transmit I/O mode to CAN, the interface still can
            receive frames in FD modes (if the XNET Cluster CAN:I/O Mode
            property is configured in an FD mode).

--- a/nixnet/session.py
+++ b/nixnet/session.py
@@ -650,23 +650,6 @@ def read_signal_xy(
     raise NotImplementedError("Placeholder")
 
 
-def read_state(
-        session_ref,
-        state_id,
-        state_size,
-        state_value,
-        fault):
-    raise NotImplementedError("Placeholder")
-
-
-def write_state(
-        session_ref,
-        state_id,
-        state_size,
-        state_value):
-    raise NotImplementedError("Placeholder")
-
-
 def write_signal_waveform(
         session_ref,
         timeout,

--- a/nixnet/session.py
+++ b/nixnet/session.py
@@ -28,8 +28,7 @@ class FrameInStreamSession(base.SessionBase):
     """Frame Input Stream session.
 
     This session reads all frames received from the network using a single
-    stream. It typically is used for analyzing and/or logging all frame traffic
-    in the network.
+    stream.
 
     The input data is returned as a list of frames. Because all frames are
     returned, your application must evaluate identification in each frame (such
@@ -52,6 +51,9 @@ class FrameInStreamSession(base.SessionBase):
     When used with a FlexRay interface, frames from both channels are returned.
     For example, if a frame is received in a static slot on both channel A and
     channel B, two frames are returned from the read function.
+
+    .. note:: Typical use case: Analyzing and/or logging all frame traffic in
+       the network.
     """
 
     def __init__(
@@ -104,8 +106,6 @@ class FrameOutStreamSession(base.SessionBase):
     each of which transmits as soon as possible. Frames transmit sequentially
     (one after another).
 
-    This session is not supported for FlexRay.
-
     Like Frame Input Stream sessions, you can create more than one Frame Output
     Stream session for a given interface.
 
@@ -127,6 +127,8 @@ class FrameOutStreamSession(base.SessionBase):
     frame for transmit is defined in the database (in-memory or otherwise), it
     is transmitted using its database checksum type. If the frame for transmit
     is not defined in the database, it is transmitted using enhanced checksum.
+
+    This session is not supported for FlexRay.
 
     The frame values for this session are stored in a queue, such that every value
     provided is transmitted.
@@ -317,9 +319,7 @@ class FrameOutQueuedSession(base.SessionBase):
 class FrameInSinglePointSession(base.SessionBase):
     """Frame Input Single-Point session.
 
-    This session reads the most recent value received for each frame. It
-    typically is used for control or simulation applications that require lower
-    level access to frames (not signals).
+    This session reads the most recent value received for each frame.
 
     This session does not use queues to store each received frame. If the
     interface receives two frames prior to calling the read frame function, that
@@ -327,6 +327,9 @@ class FrameInSinglePointSession(base.SessionBase):
 
     The input data is returned as a list of frames, one for each frame
     specified for the session.
+
+    .. note:: Typical use case: Control or simulation applications that require
+       lower level access to frames (not signals).
     """
 
     def __init__(
@@ -384,9 +387,7 @@ class FrameInSinglePointSession(base.SessionBase):
 class FrameOutSinglePointSession(base.SessionBase):
     """Frame Output Single-Point session.
 
-    This session writes frame values for the next transmit. It typically is used
-    for control or simulation applications that require lower level access to
-    frames (not signals).
+    This session writes frame values for the next transmit.
 
     This session does not use queues to store frame values. If the write frame
     function is called twice before the next transmit, the transmitted frame
@@ -405,6 +406,9 @@ class FrameOutSinglePointSession(base.SessionBase):
     than the Payload Length configured in the database, the queue is flushed and
     no frames transmit. For other interfaces, transmitting a number of payload
     bytes different than the frame payload may cause unexpected results on the bus.
+
+    .. note:: Typical use case: Control or simulation applications that require lower level access
+       to frames (not signals).
     """
     def __init__(
             self,
@@ -461,9 +465,7 @@ class FrameOutSinglePointSession(base.SessionBase):
 class SignalInSinglePointSession(base.SessionBase):
     """Signal Input Single-Point session.
 
-    This session reads the most recent value received for each signal. It
-    typically is used for control or simulation applications, such as Hardware
-    In the Loop (HIL).
+    This session reads the most recent value received for each signal.
 
     This session does not use queues to store each received frame. If the
     interface receives two frames prior to calling
@@ -483,6 +485,9 @@ class SignalInSinglePointSession(base.SessionBase):
     name :trigger:.<frame name>.<signal name>. This signal returns 1.0 only if a
     frame with appropriate set multiplexer bit has been received since the last
     Read or Start.
+
+    .. note:: Typical use case: Control or simulation applications, such as
+       Hardware In the Loop (HIL).
     """
 
     def __init__(
@@ -545,9 +550,7 @@ class SignalInSinglePointSession(base.SessionBase):
 class SignalOutSinglePointSession(base.SessionBase):
     """Signal Out Single-Point session.
 
-    This session writes signal values for the next frame transmit. It typically
-    is used for control or simulation applications, such as Hardware In the Loop
-    (HIL).
+    This session writes signal values for the next frame transmit.
 
     This session does not use queues to store signal values. If
     :any:`nixnet._session.signals.SinglePointOutSignals.write` is called twice
@@ -561,6 +564,9 @@ class SignalOutSinglePointSession(base.SessionBase):
     list, you can write a value of 0.0 to suppress writing of that frame, or any
     value not equal to 0.0 to write the frame. You can specify multiple trigger
     signals for different frames in the same session.
+
+    .. note:: Typical use case: Control or simulation applications, such as
+       Hardware In the Loop (HIL).
     """
 
     def __init__(


### PR DESCRIPTION
This will better match how the API is used.

- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nixnet-python/blob/master/CONTRIBUTING.rst).
- [x] New tests have been created for any new features or regression tests for bugfixes.
- [x] `tox` successfully runs, including unit tests and style checks (see [CONTRIBUTING.md](https://github.com/ni/nixnet-python/blob/master/CONTRIBUTING.rst)).