### PR TITLE
fix: Improve thread safety

### DIFF
--- a/nixnet/_cfuncs.py
+++ b/nixnet/_cfuncs.py
@@ -3,6 +3,7 @@ from __future__ import division
 from __future__ import print_function
 
 import ctypes  # type: ignore
+import threading
 import typing  # NOQA: F401
 
 from nixnet import _ctypedefs
@@ -19,6 +20,57 @@ class XnetLibrary(object):
 
     def __init__(self):
         self._cdll = None
+        self._load_lock = threading.Lock()
+        self._nx_create_session = None
+        self._nx_create_session_by_ref = None
+        self._nx_get_property = None
+        self._nx_get_property_size = None
+        self._nx_set_property = None
+        self._nx_get_sub_property = None
+        self._nx_get_sub_property_size = None
+        self._nx_set_sub_property = None
+        self._nx_read_frame = None
+        self._nx_read_signal_single_point = None
+        self._nx_read_signal_waveform = None
+        self._nx_read_signal_xy = None
+        self._nx_read_state = None
+        self._nx_write_frame = None
+        self._nx_write_signal_single_point = None
+        self._nx_write_state = None
+        self._nx_write_signal_waveform = None
+        self._nx_write_signal_xy = None
+        self._nx_convert_frames_to_signals_single_point = None
+        self._nx_convert_signals_to_frames_single_point = None
+        self._nx_blink = None
+        self._nx_clear = None
+        self._nx_connect_terminals = None
+        self._nx_disconnect_terminals = None
+        self._nx_flush = None
+        self._nx_start = None
+        self._nx_stop = None
+        self._nx_status_to_string = None
+        self._nx_system_open = None
+        self._nx_system_close = None
+        self._nx_wait = None
+        self._nxdb_open_database = None
+        self._nxdb_close_database = None
+        self._nxdb_create_object = None
+        self._nxdb_find_object = None
+        self._nxdb_delete_object = None
+        self._nxdb_save_database = None
+        self._nxdb_get_property = None
+        self._nxdb_get_property_size = None
+        self._nxdb_set_property = None
+        self._nxdb_get_dbc_attribute_size = None
+        self._nxdb_get_dbc_attribute = None
+        self._nxdb_merge = None
+        self._nxdb_add_alias = None
+        self._nxdb_add_alias64 = None
+        self._nxdb_remove_alias = None
+        self._nxdb_deploy = None
+        self._nxdb_undeploy = None
+        self._nxdb_get_database_list = None
+        self._nxdb_get_database_list_sizes = None
 
     @property
     def cdll(self):
@@ -37,16 +89,19 @@ class XnetLibrary(object):
             session_ref,  # type: typing.Any
     ):
         # type: (...) -> _ctypedefs.nxStatus_t
-        cfunc = self.cdll.nxCreateSession
-        cfunc.argtypes = [
-            _ctypedefs.char_p,
-            _ctypedefs.char_p,
-            _ctypedefs.char_p,
-            _ctypedefs.char_p,
-            _ctypedefs.u32,
-            ctypes.POINTER(_ctypedefs.nxSessionRef_t)]
-        cfunc.restype = _ctypedefs.nxStatus_t
-        return cfunc(
+        if self._nx_create_session is None:
+            with self._load_lock:
+                cfunc = self.cdll.nxCreateSession
+                cfunc.argtypes = [
+                    _ctypedefs.char_p,
+                    _ctypedefs.char_p,
+                    _ctypedefs.char_p,
+                    _ctypedefs.char_p,
+                    _ctypedefs.u32,
+                    ctypes.POINTER(_ctypedefs.nxSessionRef_t)]
+                cfunc.restype = _ctypedefs.nxStatus_t
+                self._nx_create_session = cfunc
+        return self._nx_create_session(
             database_name,
             cluster_name,
             list,
@@ -63,15 +118,18 @@ class XnetLibrary(object):
             session_ref,  # type: typing.Any
     ):
         # type: (...) -> _ctypedefs.nxStatus_t
-        cfunc = self.cdll.nxCreateSessionByRef
-        cfunc.argtypes = [
-            _ctypedefs.u32,
-            ctypes.POINTER(_ctypedefs.nxDatabaseRef_t),
-            _ctypedefs.char_p,
-            _ctypedefs.u32,
-            ctypes.POINTER(_ctypedefs.nxSessionRef_t)]
-        cfunc.restype = _ctypedefs.nxStatus_t
-        return cfunc(
+        if self._nx_create_session_by_ref is None:
+            with self._load_lock:
+                cfunc = self.cdll.nxCreateSessionByRef
+                cfunc.argtypes = [
+                    _ctypedefs.u32,
+                    ctypes.POINTER(_ctypedefs.nxDatabaseRef_t),
+                    _ctypedefs.char_p,
+                    _ctypedefs.u32,
+                    ctypes.POINTER(_ctypedefs.nxSessionRef_t)]
+                cfunc.restype = _ctypedefs.nxStatus_t
+                self._nx_create_session_by_ref = cfunc
+        return self._nx_create_session_by_ref(
             size_of_database_refs,
             database_refs,
             interface,
@@ -86,14 +144,17 @@ class XnetLibrary(object):
             property_value,  # type: _ctypedefs.nxVoidPtr
     ):
         # type: (...) -> _ctypedefs.nxStatus_t
-        cfunc = self.cdll.nxGetProperty
-        cfunc.argtypes = [
-            _ctypedefs.nxSessionRef_t,
-            _ctypedefs.u32,
-            _ctypedefs.u32,
-            _ctypedefs.nxVoidPtr]
-        cfunc.restype = _ctypedefs.nxStatus_t
-        return cfunc(
+        if self._nx_get_property is None:
+            with self._load_lock:
+                cfunc = self.cdll.nxGetProperty
+                cfunc.argtypes = [
+                    _ctypedefs.nxSessionRef_t,
+                    _ctypedefs.u32,
+                    _ctypedefs.u32,
+                    _ctypedefs.nxVoidPtr]
+                cfunc.restype = _ctypedefs.nxStatus_t
+                self._nx_get_property = cfunc
+        return self._nx_get_property(
             session_ref,
             property_id,
             property_size,
@@ -106,13 +167,16 @@ class XnetLibrary(object):
             property_size,  # type: typing.Any
     ):
         # type: (...) -> _ctypedefs.nxStatus_t
-        cfunc = self.cdll.nxGetPropertySize
-        cfunc.argtypes = [
-            _ctypedefs.nxSessionRef_t,
-            _ctypedefs.u32,
-            ctypes.POINTER(_ctypedefs.u32)]
-        cfunc.restype = _ctypedefs.nxStatus_t
-        return cfunc(
+        if self._nx_get_property_size is None:
+            with self._load_lock:
+                cfunc = self.cdll.nxGetPropertySize
+                cfunc.argtypes = [
+                    _ctypedefs.nxSessionRef_t,
+                    _ctypedefs.u32,
+                    ctypes.POINTER(_ctypedefs.u32)]
+                cfunc.restype = _ctypedefs.nxStatus_t
+                self._nx_get_property_size = cfunc
+        return self._nx_get_property_size(
             session_ref,
             property_id,
             property_size)
@@ -125,14 +189,17 @@ class XnetLibrary(object):
             property_value,  # type: _ctypedefs.nxVoidPtr
     ):
         # type: (...) -> _ctypedefs.nxStatus_t
-        cfunc = self.cdll.nxSetProperty
-        cfunc.argtypes = [
-            _ctypedefs.nxSessionRef_t,
-            _ctypedefs.u32,
-            _ctypedefs.u32,
-            _ctypedefs.nxVoidPtr]
-        cfunc.restype = _ctypedefs.nxStatus_t
-        return cfunc(
+        if self._nx_set_property is None:
+            with self._load_lock:
+                cfunc = self.cdll.nxSetProperty
+                cfunc.argtypes = [
+                    _ctypedefs.nxSessionRef_t,
+                    _ctypedefs.u32,
+                    _ctypedefs.u32,
+                    _ctypedefs.nxVoidPtr]
+                cfunc.restype = _ctypedefs.nxStatus_t
+                self._nx_set_property = cfunc
+        return self._nx_set_property(
             session_ref,
             property_id,
             property_size,
@@ -147,15 +214,18 @@ class XnetLibrary(object):
             property_value,  # type: _ctypedefs.nxVoidPtr
     ):
         # type: (...) -> _ctypedefs.nxStatus_t
-        cfunc = self.cdll.nxGetSubProperty
-        cfunc.argtypes = [
-            _ctypedefs.nxSessionRef_t,
-            _ctypedefs.u32,
-            _ctypedefs.u32,
-            _ctypedefs.u32,
-            _ctypedefs.nxVoidPtr]
-        cfunc.restype = _ctypedefs.nxStatus_t
-        return cfunc(
+        if self._nx_get_sub_property is None:
+            with self._load_lock:
+                cfunc = self.cdll.nxGetSubProperty
+                cfunc.argtypes = [
+                    _ctypedefs.nxSessionRef_t,
+                    _ctypedefs.u32,
+                    _ctypedefs.u32,
+                    _ctypedefs.u32,
+                    _ctypedefs.nxVoidPtr]
+                cfunc.restype = _ctypedefs.nxStatus_t
+                self._nx_get_sub_property = cfunc
+        return self._nx_get_sub_property(
             session_ref,
             active_index,
             property_id,
@@ -170,14 +240,17 @@ class XnetLibrary(object):
             property_size,  # type: typing.Any
     ):
         # type: (...) -> _ctypedefs.nxStatus_t
-        cfunc = self.cdll.nxGetSubPropertySize
-        cfunc.argtypes = [
-            _ctypedefs.nxSessionRef_t,
-            _ctypedefs.u32,
-            _ctypedefs.u32,
-            ctypes.POINTER(_ctypedefs.u32)]
-        cfunc.restype = _ctypedefs.nxStatus_t
-        return cfunc(
+        if self._nx_get_sub_property_size is None:
+            with self._load_lock:
+                cfunc = self.cdll.nxGetSubPropertySize
+                cfunc.argtypes = [
+                    _ctypedefs.nxSessionRef_t,
+                    _ctypedefs.u32,
+                    _ctypedefs.u32,
+                    ctypes.POINTER(_ctypedefs.u32)]
+                cfunc.restype = _ctypedefs.nxStatus_t
+                self._nx_get_sub_property_size = cfunc
+        return self._nx_get_sub_property_size(
             session_ref,
             active_index,
             property_id,
@@ -192,15 +265,18 @@ class XnetLibrary(object):
             property_value,  # type: _ctypedefs.nxVoidPtr
     ):
         # type: (...) -> _ctypedefs.nxStatus_t
-        cfunc = self.cdll.nxSetSubProperty
-        cfunc.argtypes = [
-            _ctypedefs.nxSessionRef_t,
-            _ctypedefs.u32,
-            _ctypedefs.u32,
-            _ctypedefs.u32,
-            _ctypedefs.nxVoidPtr]
-        cfunc.restype = _ctypedefs.nxStatus_t
-        return cfunc(
+        if self._nx_set_sub_property is None:
+            with self._load_lock:
+                cfunc = self.cdll.nxSetSubProperty
+                cfunc.argtypes = [
+                    _ctypedefs.nxSessionRef_t,
+                    _ctypedefs.u32,
+                    _ctypedefs.u32,
+                    _ctypedefs.u32,
+                    _ctypedefs.nxVoidPtr]
+                cfunc.restype = _ctypedefs.nxStatus_t
+                self._nx_set_sub_property = cfunc
+        return self._nx_set_sub_property(
             session_ref,
             active_index,
             property_id,
@@ -216,15 +292,18 @@ class XnetLibrary(object):
             number_of_bytes_returned,  # type: typing.Any
     ):
         # type: (...) -> _ctypedefs.nxStatus_t
-        cfunc = self.cdll.nxReadFrame
-        cfunc.argtypes = [
-            _ctypedefs.nxSessionRef_t,
-            ctypes.POINTER(_ctypedefs.byte),
-            _ctypedefs.u32,
-            _ctypedefs.f64,
-            ctypes.POINTER(_ctypedefs.u32)]
-        cfunc.restype = _ctypedefs.nxStatus_t
-        return cfunc(
+        if self._nx_read_frame is None:
+            with self._load_lock:
+                cfunc = self.cdll.nxReadFrame
+                cfunc.argtypes = [
+                    _ctypedefs.nxSessionRef_t,
+                    ctypes.POINTER(_ctypedefs.byte),
+                    _ctypedefs.u32,
+                    _ctypedefs.f64,
+                    ctypes.POINTER(_ctypedefs.u32)]
+                cfunc.restype = _ctypedefs.nxStatus_t
+                self._nx_read_frame = cfunc
+        return self._nx_read_frame(
             session_ref,
             buffer,
             size_of_buffer,
@@ -240,15 +319,18 @@ class XnetLibrary(object):
             size_of_timestamp_buffer,  # type: _ctypedefs.u32
     ):
         # type: (...) -> _ctypedefs.nxStatus_t
-        cfunc = self.cdll.nxReadSignalSinglePoint
-        cfunc.argtypes = [
-            _ctypedefs.nxSessionRef_t,
-            ctypes.POINTER(_ctypedefs.f64),
-            _ctypedefs.u32,
-            ctypes.POINTER(_ctypedefs.nxTimestamp_t),
-            _ctypedefs.u32]
-        cfunc.restype = _ctypedefs.nxStatus_t
-        return cfunc(
+        if self._nx_read_signal_single_point is None:
+            with self._load_lock:
+                cfunc = self.cdll.nxReadSignalSinglePoint
+                cfunc.argtypes = [
+                    _ctypedefs.nxSessionRef_t,
+                    ctypes.POINTER(_ctypedefs.f64),
+                    _ctypedefs.u32,
+                    ctypes.POINTER(_ctypedefs.nxTimestamp_t),
+                    _ctypedefs.u32]
+                cfunc.restype = _ctypedefs.nxStatus_t
+                self._nx_read_signal_single_point = cfunc
+        return self._nx_read_signal_single_point(
             session_ref,
             value_buffer,
             size_of_value_buffer,
@@ -266,17 +348,20 @@ class XnetLibrary(object):
             number_of_values_returned,  # type: typing.Any
     ):
         # type: (...) -> _ctypedefs.nxStatus_t
-        cfunc = self.cdll.nxReadSignalWaveform
-        cfunc.argtypes = [
-            _ctypedefs.nxSessionRef_t,
-            _ctypedefs.f64,
-            ctypes.POINTER(_ctypedefs.nxTimestamp_t),
-            ctypes.POINTER(_ctypedefs.f64),
-            ctypes.POINTER(_ctypedefs.f64),
-            _ctypedefs.u32,
-            ctypes.POINTER(_ctypedefs.u32)]
-        cfunc.restype = _ctypedefs.nxStatus_t
-        return cfunc(
+        if self._nx_read_signal_waveform is None:
+            with self._load_lock:
+                cfunc = self.cdll.nxReadSignalWaveform
+                cfunc.argtypes = [
+                    _ctypedefs.nxSessionRef_t,
+                    _ctypedefs.f64,
+                    ctypes.POINTER(_ctypedefs.nxTimestamp_t),
+                    ctypes.POINTER(_ctypedefs.f64),
+                    ctypes.POINTER(_ctypedefs.f64),
+                    _ctypedefs.u32,
+                    ctypes.POINTER(_ctypedefs.u32)]
+                cfunc.restype = _ctypedefs.nxStatus_t
+                self._nx_read_signal_waveform = cfunc
+        return self._nx_read_signal_waveform(
             session_ref,
             timeout,
             start_time,
@@ -297,18 +382,21 @@ class XnetLibrary(object):
             size_of_num_pairs_buffer,  # type: _ctypedefs.u32
     ):
         # type: (...) -> _ctypedefs.nxStatus_t
-        cfunc = self.cdll.nxReadSignalXY
-        cfunc.argtypes = [
-            _ctypedefs.nxSessionRef_t,
-            ctypes.POINTER(_ctypedefs.nxTimestamp_t),
-            ctypes.POINTER(_ctypedefs.f64),
-            _ctypedefs.u32,
-            ctypes.POINTER(_ctypedefs.nxTimestamp_t),
-            _ctypedefs.u32,
-            ctypes.POINTER(_ctypedefs.u32),
-            _ctypedefs.u32]
-        cfunc.restype = _ctypedefs.nxStatus_t
-        return cfunc(
+        if self._nx_read_signal_xy is None:
+            with self._load_lock:
+                cfunc = self.cdll.nxReadSignalXY
+                cfunc.argtypes = [
+                    _ctypedefs.nxSessionRef_t,
+                    ctypes.POINTER(_ctypedefs.nxTimestamp_t),
+                    ctypes.POINTER(_ctypedefs.f64),
+                    _ctypedefs.u32,
+                    ctypes.POINTER(_ctypedefs.nxTimestamp_t),
+                    _ctypedefs.u32,
+                    ctypes.POINTER(_ctypedefs.u32),
+                    _ctypedefs.u32]
+                cfunc.restype = _ctypedefs.nxStatus_t
+                self._nx_read_signal_xy = cfunc
+        return self._nx_read_signal_xy(
             session_ref,
             time_limit,
             value_buffer,
@@ -327,15 +415,18 @@ class XnetLibrary(object):
             fault,  # type: typing.Any
     ):
         # type: (...) -> _ctypedefs.nxStatus_t
-        cfunc = self.cdll.nxReadState
-        cfunc.argtypes = [
-            _ctypedefs.nxSessionRef_t,
-            _ctypedefs.u32,
-            _ctypedefs.u32,
-            _ctypedefs.nxVoidPtr,
-            ctypes.POINTER(_ctypedefs.nxStatus_t)]
-        cfunc.restype = _ctypedefs.nxStatus_t
-        return cfunc(
+        if self._nx_read_state is None:
+            with self._load_lock:
+                cfunc = self.cdll.nxReadState
+                cfunc.argtypes = [
+                    _ctypedefs.nxSessionRef_t,
+                    _ctypedefs.u32,
+                    _ctypedefs.u32,
+                    _ctypedefs.nxVoidPtr,
+                    ctypes.POINTER(_ctypedefs.nxStatus_t)]
+                cfunc.restype = _ctypedefs.nxStatus_t
+                self._nx_read_state = cfunc
+        return self._nx_read_state(
             session_ref,
             state_id,
             state_size,
@@ -350,14 +441,17 @@ class XnetLibrary(object):
             timeout,  # type: _ctypedefs.f64
     ):
         # type: (...) -> _ctypedefs.nxStatus_t
-        cfunc = self.cdll.nxWriteFrame
-        cfunc.argtypes = [
-            _ctypedefs.nxSessionRef_t,
-            ctypes.POINTER(_ctypedefs.byte),
-            _ctypedefs.u32,
-            _ctypedefs.f64]
-        cfunc.restype = _ctypedefs.nxStatus_t
-        return cfunc(
+        if self._nx_write_frame is None:
+            with self._load_lock:
+                cfunc = self.cdll.nxWriteFrame
+                cfunc.argtypes = [
+                    _ctypedefs.nxSessionRef_t,
+                    ctypes.POINTER(_ctypedefs.byte),
+                    _ctypedefs.u32,
+                    _ctypedefs.f64]
+                cfunc.restype = _ctypedefs.nxStatus_t
+                self._nx_write_frame = cfunc
+        return self._nx_write_frame(
             session_ref,
             buffer,
             size_of_buffer,
@@ -370,13 +464,16 @@ class XnetLibrary(object):
             size_of_value_buffer,  # type: _ctypedefs.u32
     ):
         # type: (...) -> _ctypedefs.nxStatus_t
-        cfunc = self.cdll.nxWriteSignalSinglePoint
-        cfunc.argtypes = [
-            _ctypedefs.nxSessionRef_t,
-            ctypes.POINTER(_ctypedefs.f64),
-            _ctypedefs.u32]
-        cfunc.restype = _ctypedefs.nxStatus_t
-        return cfunc(
+        if self._nx_write_signal_single_point is None:
+            with self._load_lock:
+                cfunc = self.cdll.nxWriteSignalSinglePoint
+                cfunc.argtypes = [
+                    _ctypedefs.nxSessionRef_t,
+                    ctypes.POINTER(_ctypedefs.f64),
+                    _ctypedefs.u32]
+                cfunc.restype = _ctypedefs.nxStatus_t
+                self._nx_write_signal_single_point = cfunc
+        return self._nx_write_signal_single_point(
             session_ref,
             value_buffer,
             size_of_value_buffer)
@@ -389,14 +486,17 @@ class XnetLibrary(object):
             state_value,  # type: _ctypedefs.nxVoidPtr
     ):
         # type: (...) -> _ctypedefs.nxStatus_t
-        cfunc = self.cdll.nxWriteState
-        cfunc.argtypes = [
-            _ctypedefs.nxSessionRef_t,
-            _ctypedefs.u32,
-            _ctypedefs.u32,
-            _ctypedefs.nxVoidPtr]
-        cfunc.restype = _ctypedefs.nxStatus_t
-        return cfunc(
+        if self._nx_write_state is None:
+            with self._load_lock:
+                cfunc = self.cdll.nxWriteState
+                cfunc.argtypes = [
+                    _ctypedefs.nxSessionRef_t,
+                    _ctypedefs.u32,
+                    _ctypedefs.u32,
+                    _ctypedefs.nxVoidPtr]
+                cfunc.restype = _ctypedefs.nxStatus_t
+                self._nx_write_state = cfunc
+        return self._nx_write_state(
             session_ref,
             state_id,
             state_size,
@@ -410,14 +510,17 @@ class XnetLibrary(object):
             size_of_value_buffer,  # type: _ctypedefs.u32
     ):
         # type: (...) -> _ctypedefs.nxStatus_t
-        cfunc = self.cdll.nxWriteSignalWaveform
-        cfunc.argtypes = [
-            _ctypedefs.nxSessionRef_t,
-            _ctypedefs.f64,
-            ctypes.POINTER(_ctypedefs.f64),
-            _ctypedefs.u32]
-        cfunc.restype = _ctypedefs.nxStatus_t
-        return cfunc(
+        if self._nx_write_signal_waveform is None:
+            with self._load_lock:
+                cfunc = self.cdll.nxWriteSignalWaveform
+                cfunc.argtypes = [
+                    _ctypedefs.nxSessionRef_t,
+                    _ctypedefs.f64,
+                    ctypes.POINTER(_ctypedefs.f64),
+                    _ctypedefs.u32]
+                cfunc.restype = _ctypedefs.nxStatus_t
+                self._nx_write_signal_waveform = cfunc
+        return self._nx_write_signal_waveform(
             session_ref,
             timeout,
             value_buffer,
@@ -435,18 +538,21 @@ class XnetLibrary(object):
             size_of_num_pairs_buffer,  # type: _ctypedefs.u32
     ):
         # type: (...) -> _ctypedefs.nxStatus_t
-        cfunc = self.cdll.nxWriteSignalXY
-        cfunc.argtypes = [
-            _ctypedefs.nxSessionRef_t,
-            _ctypedefs.f64,
-            ctypes.POINTER(_ctypedefs.f64),
-            _ctypedefs.u32,
-            ctypes.POINTER(_ctypedefs.nxTimestamp_t),
-            _ctypedefs.u32,
-            ctypes.POINTER(_ctypedefs.u32),
-            _ctypedefs.u32]
-        cfunc.restype = _ctypedefs.nxStatus_t
-        return cfunc(
+        if self._nx_write_signal_xy is None:
+            with self._load_lock:
+                cfunc = self.cdll.nxWriteSignalXY
+                cfunc.argtypes = [
+                    _ctypedefs.nxSessionRef_t,
+                    _ctypedefs.f64,
+                    ctypes.POINTER(_ctypedefs.f64),
+                    _ctypedefs.u32,
+                    ctypes.POINTER(_ctypedefs.nxTimestamp_t),
+                    _ctypedefs.u32,
+                    ctypes.POINTER(_ctypedefs.u32),
+                    _ctypedefs.u32]
+                cfunc.restype = _ctypedefs.nxStatus_t
+                self._nx_write_signal_xy = cfunc
+        return self._nx_write_signal_xy(
             session_ref,
             timeout,
             value_buffer,
@@ -467,17 +573,20 @@ class XnetLibrary(object):
             size_of_timestamp_buffer,  # type: _ctypedefs.u32
     ):
         # type: (...) -> _ctypedefs.nxStatus_t
-        cfunc = self.cdll.nxConvertFramesToSignalsSinglePoint
-        cfunc.argtypes = [
-            _ctypedefs.nxSessionRef_t,
-            ctypes.POINTER(_ctypedefs.byte),
-            _ctypedefs.u32,
-            ctypes.POINTER(_ctypedefs.f64),
-            _ctypedefs.u32,
-            ctypes.POINTER(_ctypedefs.nxTimestamp_t),
-            _ctypedefs.u32]
-        cfunc.restype = _ctypedefs.nxStatus_t
-        return cfunc(
+        if self._nx_convert_frames_to_signals_single_point is None:
+            with self._load_lock:
+                cfunc = self.cdll.nxConvertFramesToSignalsSinglePoint
+                cfunc.argtypes = [
+                    _ctypedefs.nxSessionRef_t,
+                    ctypes.POINTER(_ctypedefs.byte),
+                    _ctypedefs.u32,
+                    ctypes.POINTER(_ctypedefs.f64),
+                    _ctypedefs.u32,
+                    ctypes.POINTER(_ctypedefs.nxTimestamp_t),
+                    _ctypedefs.u32]
+                cfunc.restype = _ctypedefs.nxStatus_t
+                self._nx_convert_frames_to_signals_single_point = cfunc
+        return self._nx_convert_frames_to_signals_single_point(
             session_ref,
             frame_buffer,
             size_of_frame_buffer,
@@ -496,16 +605,19 @@ class XnetLibrary(object):
             number_of_bytes_returned,  # type: typing.Any
     ):
         # type: (...) -> _ctypedefs.nxStatus_t
-        cfunc = self.cdll.nxConvertSignalsToFramesSinglePoint
-        cfunc.argtypes = [
-            _ctypedefs.nxSessionRef_t,
-            ctypes.POINTER(_ctypedefs.f64),
-            _ctypedefs.u32,
-            ctypes.POINTER(_ctypedefs.byte),
-            _ctypedefs.u32,
-            ctypes.POINTER(_ctypedefs.u32)]
-        cfunc.restype = _ctypedefs.nxStatus_t
-        return cfunc(
+        if self._nx_convert_signals_to_frames_single_point is None:
+            with self._load_lock:
+                cfunc = self.cdll.nxConvertSignalsToFramesSinglePoint
+                cfunc.argtypes = [
+                    _ctypedefs.nxSessionRef_t,
+                    ctypes.POINTER(_ctypedefs.f64),
+                    _ctypedefs.u32,
+                    ctypes.POINTER(_ctypedefs.byte),
+                    _ctypedefs.u32,
+                    ctypes.POINTER(_ctypedefs.u32)]
+                cfunc.restype = _ctypedefs.nxStatus_t
+                self._nx_convert_signals_to_frames_single_point = cfunc
+        return self._nx_convert_signals_to_frames_single_point(
             session_ref,
             value_buffer,
             size_of_value_buffer,
@@ -519,12 +631,15 @@ class XnetLibrary(object):
             modifier,  # type: _ctypedefs.u32
     ):
         # type: (...) -> _ctypedefs.nxStatus_t
-        cfunc = self.cdll.nxBlink
-        cfunc.argtypes = [
-            _ctypedefs.nxSessionRef_t,
-            _ctypedefs.u32]
-        cfunc.restype = _ctypedefs.nxStatus_t
-        return cfunc(
+        if self._nx_blink is None:
+            with self._load_lock:
+                cfunc = self.cdll.nxBlink
+                cfunc.argtypes = [
+                    _ctypedefs.nxSessionRef_t,
+                    _ctypedefs.u32]
+                cfunc.restype = _ctypedefs.nxStatus_t
+                self._nx_blink = cfunc
+        return self._nx_blink(
             interface_ref,
             modifier)
 
@@ -533,11 +648,14 @@ class XnetLibrary(object):
             session_ref,  # type: _ctypedefs.nxSessionRef_t
     ):
         # type: (...) -> _ctypedefs.nxStatus_t
-        cfunc = self.cdll.nxClear
-        cfunc.argtypes = [
-            _ctypedefs.nxSessionRef_t]
-        cfunc.restype = _ctypedefs.nxStatus_t
-        return cfunc(
+        if self._nx_clear is None:
+            with self._load_lock:
+                cfunc = self.cdll.nxClear
+                cfunc.argtypes = [
+                    _ctypedefs.nxSessionRef_t]
+                cfunc.restype = _ctypedefs.nxStatus_t
+                self._nx_clear = cfunc
+        return self._nx_clear(
             session_ref)
 
     def nx_connect_terminals(
@@ -547,13 +665,16 @@ class XnetLibrary(object):
             destination,  # type: _ctypedefs.char_p
     ):
         # type: (...) -> _ctypedefs.nxStatus_t
-        cfunc = self.cdll.nxConnectTerminals
-        cfunc.argtypes = [
-            _ctypedefs.nxSessionRef_t,
-            _ctypedefs.char_p,
-            _ctypedefs.char_p]
-        cfunc.restype = _ctypedefs.nxStatus_t
-        return cfunc(
+        if self._nx_connect_terminals is None:
+            with self._load_lock:
+                cfunc = self.cdll.nxConnectTerminals
+                cfunc.argtypes = [
+                    _ctypedefs.nxSessionRef_t,
+                    _ctypedefs.char_p,
+                    _ctypedefs.char_p]
+                cfunc.restype = _ctypedefs.nxStatus_t
+                self._nx_connect_terminals = cfunc
+        return self._nx_connect_terminals(
             session_ref,
             source,
             destination)
@@ -565,13 +686,16 @@ class XnetLibrary(object):
             destination,  # type: _ctypedefs.char_p
     ):
         # type: (...) -> _ctypedefs.nxStatus_t
-        cfunc = self.cdll.nxDisconnectTerminals
-        cfunc.argtypes = [
-            _ctypedefs.nxSessionRef_t,
-            _ctypedefs.char_p,
-            _ctypedefs.char_p]
-        cfunc.restype = _ctypedefs.nxStatus_t
-        return cfunc(
+        if self._nx_disconnect_terminals is None:
+            with self._load_lock:
+                cfunc = self.cdll.nxDisconnectTerminals
+                cfunc.argtypes = [
+                    _ctypedefs.nxSessionRef_t,
+                    _ctypedefs.char_p,
+                    _ctypedefs.char_p]
+                cfunc.restype = _ctypedefs.nxStatus_t
+                self._nx_disconnect_terminals = cfunc
+        return self._nx_disconnect_terminals(
             session_ref,
             source,
             destination)
@@ -581,11 +705,14 @@ class XnetLibrary(object):
             session_ref,  # type: _ctypedefs.nxSessionRef_t
     ):
         # type: (...) -> _ctypedefs.nxStatus_t
-        cfunc = self.cdll.nxFlush
-        cfunc.argtypes = [
-            _ctypedefs.nxSessionRef_t]
-        cfunc.restype = _ctypedefs.nxStatus_t
-        return cfunc(
+        if self._nx_flush is None:
+            with self._load_lock:
+                cfunc = self.cdll.nxFlush
+                cfunc.argtypes = [
+                    _ctypedefs.nxSessionRef_t]
+                cfunc.restype = _ctypedefs.nxStatus_t
+                self._nx_flush = cfunc
+        return self._nx_flush(
             session_ref)
 
     def nx_start(
@@ -594,12 +721,15 @@ class XnetLibrary(object):
             scope,  # type: _ctypedefs.u32
     ):
         # type: (...) -> _ctypedefs.nxStatus_t
-        cfunc = self.cdll.nxStart
-        cfunc.argtypes = [
-            _ctypedefs.nxSessionRef_t,
-            _ctypedefs.u32]
-        cfunc.restype = _ctypedefs.nxStatus_t
-        return cfunc(
+        if self._nx_start is None:
+            with self._load_lock:
+                cfunc = self.cdll.nxStart
+                cfunc.argtypes = [
+                    _ctypedefs.nxSessionRef_t,
+                    _ctypedefs.u32]
+                cfunc.restype = _ctypedefs.nxStatus_t
+                self._nx_start = cfunc
+        return self._nx_start(
             session_ref,
             scope)
 
@@ -609,12 +739,15 @@ class XnetLibrary(object):
             scope,  # type: _ctypedefs.u32
     ):
         # type: (...) -> _ctypedefs.nxStatus_t
-        cfunc = self.cdll.nxStop
-        cfunc.argtypes = [
-            _ctypedefs.nxSessionRef_t,
-            _ctypedefs.u32]
-        cfunc.restype = _ctypedefs.nxStatus_t
-        return cfunc(
+        if self._nx_stop is None:
+            with self._load_lock:
+                cfunc = self.cdll.nxStop
+                cfunc.argtypes = [
+                    _ctypedefs.nxSessionRef_t,
+                    _ctypedefs.u32]
+                cfunc.restype = _ctypedefs.nxStatus_t
+                self._nx_stop = cfunc
+        return self._nx_stop(
             session_ref,
             scope)
 
@@ -625,13 +758,16 @@ class XnetLibrary(object):
             status_description,  # type: _ctypedefs.char_p
     ):
         # type: (...) -> None
-        cfunc = self.cdll.nxStatusToString
-        cfunc.argtypes = [
-            _ctypedefs.nxStatus_t,
-            _ctypedefs.u32,
-            _ctypedefs.char_p]
-        cfunc.restype = None
-        return cfunc(
+        if self._nx_status_to_string is None:
+            with self._load_lock:
+                cfunc = self.cdll.nxStatusToString
+                cfunc.argtypes = [
+                    _ctypedefs.nxStatus_t,
+                    _ctypedefs.u32,
+                    _ctypedefs.char_p]
+                cfunc.restype = None
+                self._nx_status_to_string = cfunc
+        return self._nx_status_to_string(
             status,
             size_of_status_description,
             status_description)
@@ -641,11 +777,14 @@ class XnetLibrary(object):
             system_ref,  # type: typing.Any
     ):
         # type: (...) -> _ctypedefs.nxStatus_t
-        cfunc = self.cdll.nxSystemOpen
-        cfunc.argtypes = [
-            ctypes.POINTER(_ctypedefs.nxSessionRef_t)]
-        cfunc.restype = _ctypedefs.nxStatus_t
-        return cfunc(
+        if self._nx_system_open is None:
+            with self._load_lock:
+                cfunc = self.cdll.nxSystemOpen
+                cfunc.argtypes = [
+                    ctypes.POINTER(_ctypedefs.nxSessionRef_t)]
+                cfunc.restype = _ctypedefs.nxStatus_t
+                self._nx_system_open = cfunc
+        return self._nx_system_open(
             system_ref)
 
     def nx_system_close(
@@ -653,11 +792,14 @@ class XnetLibrary(object):
             system_ref,  # type: _ctypedefs.nxSessionRef_t
     ):
         # type: (...) -> _ctypedefs.nxStatus_t
-        cfunc = self.cdll.nxSystemClose
-        cfunc.argtypes = [
-            _ctypedefs.nxSessionRef_t]
-        cfunc.restype = _ctypedefs.nxStatus_t
-        return cfunc(
+        if self._nx_system_close is None:
+            with self._load_lock:
+                cfunc = self.cdll.nxSystemClose
+                cfunc.argtypes = [
+                    _ctypedefs.nxSessionRef_t]
+                cfunc.restype = _ctypedefs.nxStatus_t
+                self._nx_system_close = cfunc
+        return self._nx_system_close(
             system_ref)
 
     def nx_wait(
@@ -669,15 +811,18 @@ class XnetLibrary(object):
             param_out,  # type: typing.Any
     ):
         # type: (...) -> _ctypedefs.nxStatus_t
-        cfunc = self.cdll.nxWait
-        cfunc.argtypes = [
-            _ctypedefs.nxSessionRef_t,
-            _ctypedefs.u32,
-            _ctypedefs.u32,
-            _ctypedefs.f64,
-            ctypes.POINTER(_ctypedefs.u32)]
-        cfunc.restype = _ctypedefs.nxStatus_t
-        return cfunc(
+        if self._nx_wait is None:
+            with self._load_lock:
+                cfunc = self.cdll.nxWait
+                cfunc.argtypes = [
+                    _ctypedefs.nxSessionRef_t,
+                    _ctypedefs.u32,
+                    _ctypedefs.u32,
+                    _ctypedefs.f64,
+                    ctypes.POINTER(_ctypedefs.u32)]
+                cfunc.restype = _ctypedefs.nxStatus_t
+                self._nx_wait = cfunc
+        return self._nx_wait(
             session_ref,
             condition,
             param_in,
@@ -690,12 +835,15 @@ class XnetLibrary(object):
             database_ref,  # type: typing.Any
     ):
         # type: (...) -> _ctypedefs.nxStatus_t
-        cfunc = self.cdll.nxdbOpenDatabase
-        cfunc.argtypes = [
-            _ctypedefs.char_p,
-            ctypes.POINTER(_ctypedefs.nxDatabaseRef_t)]
-        cfunc.restype = _ctypedefs.nxStatus_t
-        return cfunc(
+        if self._nxdb_open_database is None:
+            with self._load_lock:
+                cfunc = self.cdll.nxdbOpenDatabase
+                cfunc.argtypes = [
+                    _ctypedefs.char_p,
+                    ctypes.POINTER(_ctypedefs.nxDatabaseRef_t)]
+                cfunc.restype = _ctypedefs.nxStatus_t
+                self._nxdb_open_database = cfunc
+        return self._nxdb_open_database(
             database_name,
             database_ref)
 
@@ -705,12 +853,15 @@ class XnetLibrary(object):
             close_all_refs,  # type: _ctypedefs.bool32
     ):
         # type: (...) -> _ctypedefs.nxStatus_t
-        cfunc = self.cdll.nxdbCloseDatabase
-        cfunc.argtypes = [
-            _ctypedefs.nxDatabaseRef_t,
-            _ctypedefs.bool32]
-        cfunc.restype = _ctypedefs.nxStatus_t
-        return cfunc(
+        if self._nxdb_close_database is None:
+            with self._load_lock:
+                cfunc = self.cdll.nxdbCloseDatabase
+                cfunc.argtypes = [
+                    _ctypedefs.nxDatabaseRef_t,
+                    _ctypedefs.bool32]
+                cfunc.restype = _ctypedefs.nxStatus_t
+                self._nxdb_close_database = cfunc
+        return self._nxdb_close_database(
             database_ref,
             close_all_refs)
 
@@ -722,14 +873,17 @@ class XnetLibrary(object):
             db_object_ref,  # type: typing.Any
     ):
         # type: (...) -> _ctypedefs.nxStatus_t
-        cfunc = self.cdll.nxdbCreateObject
-        cfunc.argtypes = [
-            _ctypedefs.nxDatabaseRef_t,
-            _ctypedefs.u32,
-            _ctypedefs.char_p,
-            ctypes.POINTER(_ctypedefs.nxDatabaseRef_t)]
-        cfunc.restype = _ctypedefs.nxStatus_t
-        return cfunc(
+        if self._nxdb_create_object is None:
+            with self._load_lock:
+                cfunc = self.cdll.nxdbCreateObject
+                cfunc.argtypes = [
+                    _ctypedefs.nxDatabaseRef_t,
+                    _ctypedefs.u32,
+                    _ctypedefs.char_p,
+                    ctypes.POINTER(_ctypedefs.nxDatabaseRef_t)]
+                cfunc.restype = _ctypedefs.nxStatus_t
+                self._nxdb_create_object = cfunc
+        return self._nxdb_create_object(
             parent_object_ref,
             object_class,
             object_name,
@@ -743,14 +897,17 @@ class XnetLibrary(object):
             db_object_ref,  # type: typing.Any
     ):
         # type: (...) -> _ctypedefs.nxStatus_t
-        cfunc = self.cdll.nxdbFindObject
-        cfunc.argtypes = [
-            _ctypedefs.nxDatabaseRef_t,
-            _ctypedefs.u32,
-            _ctypedefs.char_p,
-            ctypes.POINTER(_ctypedefs.nxDatabaseRef_t)]
-        cfunc.restype = _ctypedefs.nxStatus_t
-        return cfunc(
+        if self._nxdb_find_object is None:
+            with self._load_lock:
+                cfunc = self.cdll.nxdbFindObject
+                cfunc.argtypes = [
+                    _ctypedefs.nxDatabaseRef_t,
+                    _ctypedefs.u32,
+                    _ctypedefs.char_p,
+                    ctypes.POINTER(_ctypedefs.nxDatabaseRef_t)]
+                cfunc.restype = _ctypedefs.nxStatus_t
+                self._nxdb_find_object = cfunc
+        return self._nxdb_find_object(
             parent_object_ref,
             object_class,
             object_name,
@@ -761,11 +918,14 @@ class XnetLibrary(object):
             db_object_ref,  # type: _ctypedefs.nxDatabaseRef_t
     ):
         # type: (...) -> _ctypedefs.nxStatus_t
-        cfunc = self.cdll.nxdbDeleteObject
-        cfunc.argtypes = [
-            _ctypedefs.nxDatabaseRef_t]
-        cfunc.restype = _ctypedefs.nxStatus_t
-        return cfunc(
+        if self._nxdb_delete_object is None:
+            with self._load_lock:
+                cfunc = self.cdll.nxdbDeleteObject
+                cfunc.argtypes = [
+                    _ctypedefs.nxDatabaseRef_t]
+                cfunc.restype = _ctypedefs.nxStatus_t
+                self._nxdb_delete_object = cfunc
+        return self._nxdb_delete_object(
             db_object_ref)
 
     def nxdb_save_database(
@@ -774,12 +934,15 @@ class XnetLibrary(object):
             db_filepath,  # type: _ctypedefs.char_p
     ):
         # type: (...) -> _ctypedefs.nxStatus_t
-        cfunc = self.cdll.nxdbSaveDatabase
-        cfunc.argtypes = [
-            _ctypedefs.nxDatabaseRef_t,
-            _ctypedefs.char_p]
-        cfunc.restype = _ctypedefs.nxStatus_t
-        return cfunc(
+        if self._nxdb_save_database is None:
+            with self._load_lock:
+                cfunc = self.cdll.nxdbSaveDatabase
+                cfunc.argtypes = [
+                    _ctypedefs.nxDatabaseRef_t,
+                    _ctypedefs.char_p]
+                cfunc.restype = _ctypedefs.nxStatus_t
+                self._nxdb_save_database = cfunc
+        return self._nxdb_save_database(
             database_ref,
             db_filepath)
 
@@ -791,14 +954,17 @@ class XnetLibrary(object):
             property_value,  # type: _ctypedefs.nxVoidPtr
     ):
         # type: (...) -> _ctypedefs.nxStatus_t
-        cfunc = self.cdll.nxdbGetProperty
-        cfunc.argtypes = [
-            _ctypedefs.nxDatabaseRef_t,
-            _ctypedefs.u32,
-            _ctypedefs.u32,
-            _ctypedefs.nxVoidPtr]
-        cfunc.restype = _ctypedefs.nxStatus_t
-        return cfunc(
+        if self._nxdb_get_property is None:
+            with self._load_lock:
+                cfunc = self.cdll.nxdbGetProperty
+                cfunc.argtypes = [
+                    _ctypedefs.nxDatabaseRef_t,
+                    _ctypedefs.u32,
+                    _ctypedefs.u32,
+                    _ctypedefs.nxVoidPtr]
+                cfunc.restype = _ctypedefs.nxStatus_t
+                self._nxdb_get_property = cfunc
+        return self._nxdb_get_property(
             db_object_ref,
             property_id,
             property_size,
@@ -811,13 +977,16 @@ class XnetLibrary(object):
             property_size,  # type: typing.Any
     ):
         # type: (...) -> _ctypedefs.nxStatus_t
-        cfunc = self.cdll.nxdbGetPropertySize
-        cfunc.argtypes = [
-            _ctypedefs.nxDatabaseRef_t,
-            _ctypedefs.u32,
-            ctypes.POINTER(_ctypedefs.u32)]
-        cfunc.restype = _ctypedefs.nxStatus_t
-        return cfunc(
+        if self._nxdb_get_property_size is None:
+            with self._load_lock:
+                cfunc = self.cdll.nxdbGetPropertySize
+                cfunc.argtypes = [
+                    _ctypedefs.nxDatabaseRef_t,
+                    _ctypedefs.u32,
+                    ctypes.POINTER(_ctypedefs.u32)]
+                cfunc.restype = _ctypedefs.nxStatus_t
+                self._nxdb_get_property_size = cfunc
+        return self._nxdb_get_property_size(
             db_object_ref,
             property_id,
             property_size)
@@ -830,14 +999,17 @@ class XnetLibrary(object):
             property_value,  # type: _ctypedefs.nxVoidPtr
     ):
         # type: (...) -> _ctypedefs.nxStatus_t
-        cfunc = self.cdll.nxdbSetProperty
-        cfunc.argtypes = [
-            _ctypedefs.nxDatabaseRef_t,
-            _ctypedefs.u32,
-            _ctypedefs.u32,
-            _ctypedefs.nxVoidPtr]
-        cfunc.restype = _ctypedefs.nxStatus_t
-        return cfunc(
+        if self._nxdb_set_property is None:
+            with self._load_lock:
+                cfunc = self.cdll.nxdbSetProperty
+                cfunc.argtypes = [
+                    _ctypedefs.nxDatabaseRef_t,
+                    _ctypedefs.u32,
+                    _ctypedefs.u32,
+                    _ctypedefs.nxVoidPtr]
+                cfunc.restype = _ctypedefs.nxStatus_t
+                self._nxdb_set_property = cfunc
+        return self._nxdb_set_property(
             db_object_ref,
             property_id,
             property_size,
@@ -851,14 +1023,17 @@ class XnetLibrary(object):
             attribute_text_size,  # type: typing.Any
     ):
         # type: (...) -> _ctypedefs.nxStatus_t
-        cfunc = self.cdll.nxdbGetDBCAttributeSize
-        cfunc.argtypes = [
-            _ctypedefs.nxDatabaseRef_t,
-            _ctypedefs.u32,
-            _ctypedefs.char_p,
-            ctypes.POINTER(_ctypedefs.u32)]
-        cfunc.restype = _ctypedefs.nxStatus_t
-        return cfunc(
+        if self._nxdb_get_dbc_attribute_size is None:
+            with self._load_lock:
+                cfunc = self.cdll.nxdbGetDBCAttributeSize
+                cfunc.argtypes = [
+                    _ctypedefs.nxDatabaseRef_t,
+                    _ctypedefs.u32,
+                    _ctypedefs.char_p,
+                    ctypes.POINTER(_ctypedefs.u32)]
+                cfunc.restype = _ctypedefs.nxStatus_t
+                self._nxdb_get_dbc_attribute_size = cfunc
+        return self._nxdb_get_dbc_attribute_size(
             db_object_ref,
             mode,
             attribute_name,
@@ -874,16 +1049,19 @@ class XnetLibrary(object):
             is_default,  # type: typing.Any
     ):
         # type: (...) -> _ctypedefs.nxStatus_t
-        cfunc = self.cdll.nxdbGetDBCAttribute
-        cfunc.argtypes = [
-            _ctypedefs.nxDatabaseRef_t,
-            _ctypedefs.u32,
-            _ctypedefs.char_p,
-            _ctypedefs.u32,
-            _ctypedefs.char_p,
-            ctypes.POINTER(_ctypedefs.u32)]
-        cfunc.restype = _ctypedefs.nxStatus_t
-        return cfunc(
+        if self._nxdb_get_dbc_attribute is None:
+            with self._load_lock:
+                cfunc = self.cdll.nxdbGetDBCAttribute
+                cfunc.argtypes = [
+                    _ctypedefs.nxDatabaseRef_t,
+                    _ctypedefs.u32,
+                    _ctypedefs.char_p,
+                    _ctypedefs.u32,
+                    _ctypedefs.char_p,
+                    ctypes.POINTER(_ctypedefs.u32)]
+                cfunc.restype = _ctypedefs.nxStatus_t
+                self._nxdb_get_dbc_attribute = cfunc
+        return self._nxdb_get_dbc_attribute(
             db_object_ref,
             mode,
             attribute_name,
@@ -901,16 +1079,19 @@ class XnetLibrary(object):
             percent_complete,  # type: typing.Any
     ):
         # type: (...) -> _ctypedefs.nxStatus_t
-        cfunc = self.cdll.nxdbMerge
-        cfunc.argtypes = [
-            _ctypedefs.nxDatabaseRef_t,
-            _ctypedefs.nxDatabaseRef_t,
-            _ctypedefs.u32,
-            _ctypedefs.char_p,
-            _ctypedefs.bool32,
-            ctypes.POINTER(_ctypedefs.u32)]
-        cfunc.restype = _ctypedefs.nxStatus_t
-        return cfunc(
+        if self._nxdb_merge is None:
+            with self._load_lock:
+                cfunc = self.cdll.nxdbMerge
+                cfunc.argtypes = [
+                    _ctypedefs.nxDatabaseRef_t,
+                    _ctypedefs.nxDatabaseRef_t,
+                    _ctypedefs.u32,
+                    _ctypedefs.char_p,
+                    _ctypedefs.bool32,
+                    ctypes.POINTER(_ctypedefs.u32)]
+                cfunc.restype = _ctypedefs.nxStatus_t
+                self._nxdb_merge = cfunc
+        return self._nxdb_merge(
             target_cluster_ref,
             source_obj_ref,
             copy_mode,
@@ -925,13 +1106,16 @@ class XnetLibrary(object):
             default_baud_rate,  # type: _ctypedefs.u32
     ):
         # type: (...) -> _ctypedefs.nxStatus_t
-        cfunc = self.cdll.nxdbAddAlias
-        cfunc.argtypes = [
-            _ctypedefs.char_p,
-            _ctypedefs.char_p,
-            _ctypedefs.u32]
-        cfunc.restype = _ctypedefs.nxStatus_t
-        return cfunc(
+        if self._nxdb_add_alias is None:
+            with self._load_lock:
+                cfunc = self.cdll.nxdbAddAlias
+                cfunc.argtypes = [
+                    _ctypedefs.char_p,
+                    _ctypedefs.char_p,
+                    _ctypedefs.u32]
+                cfunc.restype = _ctypedefs.nxStatus_t
+                self._nxdb_add_alias = cfunc
+        return self._nxdb_add_alias(
             database_alias,
             database_filepath,
             default_baud_rate)
@@ -943,13 +1127,16 @@ class XnetLibrary(object):
             default_baud_rate,  # type: _ctypedefs.u64
     ):
         # type: (...) -> _ctypedefs.nxStatus_t
-        cfunc = self.cdll.nxdbAddAlias64
-        cfunc.argtypes = [
-            _ctypedefs.char_p,
-            _ctypedefs.char_p,
-            _ctypedefs.u64]
-        cfunc.restype = _ctypedefs.nxStatus_t
-        return cfunc(
+        if self._nxdb_add_alias64 is None:
+            with self._load_lock:
+                cfunc = self.cdll.nxdbAddAlias64
+                cfunc.argtypes = [
+                    _ctypedefs.char_p,
+                    _ctypedefs.char_p,
+                    _ctypedefs.u64]
+                cfunc.restype = _ctypedefs.nxStatus_t
+                self._nxdb_add_alias64 = cfunc
+        return self._nxdb_add_alias64(
             database_alias,
             database_filepath,
             default_baud_rate)
@@ -959,11 +1146,14 @@ class XnetLibrary(object):
             database_alias,  # type: _ctypedefs.char_p
     ):
         # type: (...) -> _ctypedefs.nxStatus_t
-        cfunc = self.cdll.nxdbRemoveAlias
-        cfunc.argtypes = [
-            _ctypedefs.char_p]
-        cfunc.restype = _ctypedefs.nxStatus_t
-        return cfunc(
+        if self._nxdb_remove_alias is None:
+            with self._load_lock:
+                cfunc = self.cdll.nxdbRemoveAlias
+                cfunc.argtypes = [
+                    _ctypedefs.char_p]
+                cfunc.restype = _ctypedefs.nxStatus_t
+                self._nxdb_remove_alias = cfunc
+        return self._nxdb_remove_alias(
             database_alias)
 
     def nxdb_deploy(
@@ -974,14 +1164,17 @@ class XnetLibrary(object):
             percent_complete,  # type: typing.Any
     ):
         # type: (...) -> _ctypedefs.nxStatus_t
-        cfunc = self.cdll.nxdbDeploy
-        cfunc.argtypes = [
-            _ctypedefs.char_p,
-            _ctypedefs.char_p,
-            _ctypedefs.bool32,
-            ctypes.POINTER(_ctypedefs.u32)]
-        cfunc.restype = _ctypedefs.nxStatus_t
-        return cfunc(
+        if self._nxdb_deploy is None:
+            with self._load_lock:
+                cfunc = self.cdll.nxdbDeploy
+                cfunc.argtypes = [
+                    _ctypedefs.char_p,
+                    _ctypedefs.char_p,
+                    _ctypedefs.bool32,
+                    ctypes.POINTER(_ctypedefs.u32)]
+                cfunc.restype = _ctypedefs.nxStatus_t
+                self._nxdb_deploy = cfunc
+        return self._nxdb_deploy(
             ip_address,
             database_alias,
             wait_for_complete,
@@ -993,12 +1186,15 @@ class XnetLibrary(object):
             database_alias,  # type: _ctypedefs.char_p
     ):
         # type: (...) -> _ctypedefs.nxStatus_t
-        cfunc = self.cdll.nxdbUndeploy
-        cfunc.argtypes = [
-            _ctypedefs.char_p,
-            _ctypedefs.char_p]
-        cfunc.restype = _ctypedefs.nxStatus_t
-        return cfunc(
+        if self._nxdb_undeploy is None:
+            with self._load_lock:
+                cfunc = self.cdll.nxdbUndeploy
+                cfunc.argtypes = [
+                    _ctypedefs.char_p,
+                    _ctypedefs.char_p]
+                cfunc.restype = _ctypedefs.nxStatus_t
+                self._nxdb_undeploy = cfunc
+        return self._nxdb_undeploy(
             ip_address,
             database_alias)
 
@@ -1012,16 +1208,19 @@ class XnetLibrary(object):
             number_of_databases,  # type: typing.Any
     ):
         # type: (...) -> _ctypedefs.nxStatus_t
-        cfunc = self.cdll.nxdbGetDatabaseList
-        cfunc.argtypes = [
-            _ctypedefs.char_p,
-            _ctypedefs.u32,
-            _ctypedefs.char_p,
-            _ctypedefs.u32,
-            _ctypedefs.char_p,
-            ctypes.POINTER(_ctypedefs.u32)]
-        cfunc.restype = _ctypedefs.nxStatus_t
-        return cfunc(
+        if self._nxdb_get_database_list is None:
+            with self._load_lock:
+                cfunc = self.cdll.nxdbGetDatabaseList
+                cfunc.argtypes = [
+                    _ctypedefs.char_p,
+                    _ctypedefs.u32,
+                    _ctypedefs.char_p,
+                    _ctypedefs.u32,
+                    _ctypedefs.char_p,
+                    ctypes.POINTER(_ctypedefs.u32)]
+                cfunc.restype = _ctypedefs.nxStatus_t
+                self._nxdb_get_database_list = cfunc
+        return self._nxdb_get_database_list(
             ip_address,
             size_of_alias_buffer,
             alias_buffer,
@@ -1036,13 +1235,16 @@ class XnetLibrary(object):
             sizeof_filepath_buffer,  # type: _ctypedefs.u32
     ):
         # type: (...) -> _ctypedefs.nxStatus_t
-        cfunc = self.cdll.nxdbGetDatabaseListSizes
-        cfunc.argtypes = [
-            _ctypedefs.char_p,
-            ctypes.POINTER(_ctypedefs.u32),
-            ctypes.POINTER(_ctypedefs.u32)]
-        cfunc.restype = _ctypedefs.nxStatus_t
-        return cfunc(
+        if self._nxdb_get_database_list_sizes is None:
+            with self._load_lock:
+                cfunc = self.cdll.nxdbGetDatabaseListSizes
+                cfunc.argtypes = [
+                    _ctypedefs.char_p,
+                    ctypes.POINTER(_ctypedefs.u32),
+                    ctypes.POINTER(_ctypedefs.u32)]
+                cfunc.restype = _ctypedefs.nxStatus_t
+                self._nxdb_get_database_list_sizes = cfunc
+        return self._nxdb_get_database_list_sizes(
             ip_address,
             sizeof_alias_buffer,
             sizeof_filepath_buffer)


### PR DESCRIPTION
While nixnet doesn't have callbacks to exacerbatge the problem, still
wanting to protect things.  nidaqmx went with a per-function lock.  That
is probably overkill for our needs so going with a global library loading
lock.

Not introducing double-check locking into the picture because the
conditional initialization is just an optimization.  nixnet should not
have any problems if two threads make it into the initialization check,
especially considering every call did initalization in the past.

Fixes #146

- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nixnet-python/blob/master/CONTRIBUTING.rst).
- [x] New tests have been created for any new features or regression tests for bugfixes.
- [x] `tox` successfully runs, including unit tests and style checks (see [CONTRIBUTING.md](https://github.com/ni/nixnet-python/blob/master/CONTRIBUTING.rst)).