### PR TITLE
fix(tests): CanBusErrorFrame repr was untested

### DIFF
--- a/nixnet/types.py
+++ b/nixnet/types.py
@@ -458,10 +458,10 @@ class CanBusErrorFrame(Frame):
 
     def __repr__(self):
         # type: () -> typing.Text
-        """StartTriggerFrame debug representation.
+        """CanBusErrorFrame debug representation.
 
-        >>> StartTriggerFrame(250)
-        StartTriggerFrame(0xfa)
+        >>> CanBusErrorFrame(100, constants.CanCommState.BUS_OFF, True, constants.CanLastErr.STUFF, 1, 2)
+        CanBusErrorFrame(0x64, CanCommState.BUS_OFF, True, CanLastErr.STUFF, 1, 2)
         """
         return "CanBusErrorFrame(0x{:x}, {}, {}, {}, {}, {})".format(
             self.timestamp,


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nixnet-python/blob/master/CONTRIBUTING.rst).
- [x] New tests have been created for any new features or regression tests for bugfixes.
- [x] `tox` successfully runs, including unit tests and style checks (see [CONTRIBUTING.md](https://github.com/ni/nixnet-python/blob/master/CONTRIBUTING.rst)).