### PR TITLE
Signal cleanup

### DIFF
--- a/nixnet/_session/frames.py
+++ b/nixnet/_session/frames.py
@@ -52,7 +52,7 @@ class InFrames(Frames):
 
     def read_bytes(
             self,
-            num_bytes_to_read,
+            num_bytes,
             timeout=constants.TIMEOUT_NONE):
         # type: (int, float) -> bytes
         """Read data as a list of raw bytes (frame data).
@@ -60,14 +60,14 @@ class InFrames(Frames):
         The raw bytes encode one or more frames using the Raw Frame Format.
 
         Args:
-            num_bytes_to_read(int): The number of bytes to read.
+            num_bytes(int): The number of bytes to read.
             timeout(float): The time in seconds to wait for number to read
                 frame bytes to become available.
 
                 To avoid returning a partial frame, even when
-                'num_bytes_to_read' are available from the hardware, this
+                'num_bytes' are available from the hardware, this
                 read may return fewer bytes in buffer. For example, assume you
-                pass 'num_bytes_to_read' 70 bytes and 'timeout' of 10
+                pass 'num_bytes' 70 bytes and 'timeout' of 10
                 seconds. During the read, two frames are received, the first 24
                 bytes in size, and the second 56 bytes in size, for a total of
                 80 bytes. The read returns after the two frames are received,
@@ -78,48 +78,48 @@ class InFrames(Frames):
                 buffer.
 
                 If 'timeout' is positive, this function waits for
-                'num_bytes_to_read' frame bytes to be received, then
+                'num_bytes' frame bytes to be received, then
                 returns complete frames up to that number. If the bytes do not
                 arrive prior to the 'timeout', an error is returned.
 
                 If 'timeout' is 'constants.TIMEOUT_INFINITE', this
-                function waits indefinitely for 'num_bytes_to_read' frame bytes.
+                function waits indefinitely for 'num_bytes' frame bytes.
 
                 If 'timeout' is 'constants.TIMEOUT_NONE', this
                 function does not wait and immediately returns all available
-                frame bytes up to the limit 'num_bytes_to_read' specifies.
+                frame bytes up to the limit 'num_bytes' specifies.
 
         Returns:
             A list of raw bytes representing the data.
         """
-        buffer, number_of_bytes_returned = _funcs.nx_read_frame(self._handle, num_bytes_to_read, timeout)
+        buffer, number_of_bytes_returned = _funcs.nx_read_frame(self._handle, num_bytes, timeout)
         return buffer[0:number_of_bytes_returned]
 
     def read(
             self,
-            num_frames_to_read,
+            num_frames,
             timeout=constants.TIMEOUT_NONE,
             frame_type=types.XnetFrame):
         # type: (int, float, typing.Type[types.FrameFactory]) -> typing.Iterable[types.Frame]
         """Read raw CAN frames.
 
         Args:
-            num_frames_to_read(int): Number of raw CAN frames
+            num_frames(int): Number of raw CAN frames
                 to read.
             timeout(float): The time in seconds to wait for number to read
                 frame bytes to become available.
 
                 If 'timeout' is positive, this function waits for
-                'num_frames_to_read' frames to be received, then
+                'num_frames' frames to be received, then
                 returns complete frames up to that number. If the frames do not
                 arrive prior to the 'timeout', an error is returned.
 
                 If 'timeout' is 'constants.TIMEOUT_INFINITE', this function
-                waits indefinitely for 'num_frames_to_read' frames.
+                waits indefinitely for 'num_frames' frames.
 
                 If 'timeout' is 'constants.TIMEOUT_NONE', this function does not
                 wait and immediately returns all available frames up to the
-                limit 'num_frames_to_read' specifies.
+                limit 'num_frames' specifies.
             frame_type(:any:`nixnet.types.FrameFactory`): A factory for the
                 desired frame formats.
 
@@ -128,9 +128,9 @@ class InFrames(Frames):
         """
         from_raw = typing.cast(typing.Callable[[types.RawFrame], types.Frame], frame_type.from_raw)
         # NOTE: If the frame payload exceeds the base unit, this will return
-        # less than num_frames_to_read
-        num_bytes_to_read = num_frames_to_read * _frames.nxFrameFixed_t.size
-        buffer = self.read_bytes(num_bytes_to_read, timeout)
+        # less than num_frames
+        num_bytes = num_frames * _frames.nxFrameFixed_t.size
+        buffer = self.read_bytes(num_bytes, timeout)
         for frame in _frames.iterate_frames(buffer):
             yield from_raw(frame)
 
@@ -143,19 +143,19 @@ class SinglePointInFrames(Frames):
 
     def read_bytes(
             self,
-            num_bytes_to_read):
+            num_bytes):
         # type: (int) -> bytes
         """Read data as a list of raw bytes (frame data).
 
         Args:
-            num_bytes_to_read(int): Number of bytes to read.
+            num_bytes(int): Number of bytes to read.
 
         Returns:
             bytes: Raw bytes representing the data.
         """
         buffer, number_of_bytes_returned = _funcs.nx_read_frame(
             self._handle,
-            num_bytes_to_read,
+            num_bytes,
             constants.TIMEOUT_NONE)
         return buffer[0:number_of_bytes_returned]
 
@@ -174,10 +174,10 @@ class SinglePointInFrames(Frames):
         """
         from_raw = typing.cast(typing.Callable[[types.RawFrame], types.Frame], frame_type.from_raw)
         # NOTE: If the frame payload exceeds the base unit, this will return
-        # less than num_frames_to_read
-        num_frames_to_read = len(self)
-        num_bytes_to_read = num_frames_to_read * _frames.nxFrameFixed_t.size
-        buffer = self.read_bytes(num_bytes_to_read)
+        # less than num_frames
+        num_frames = len(self)
+        num_bytes = num_frames * _frames.nxFrameFixed_t.size
+        buffer = self.read_bytes(num_bytes)
         for frame in _frames.iterate_frames(buffer):
             yield from_raw(frame)
 

--- a/nixnet/_session/signals.py
+++ b/nixnet/_session/signals.py
@@ -45,7 +45,7 @@ class SinglePointInSignals(Signals):
         """Read data from a Signal Input Single-Point session.
 
         Yields:
-            A tuple of timestamp (int) and signal values (float).
+            tuple of int and float: Timestamp and signal
         """
         num_signals = len(self)
         timestamps, values = _funcs.nx_read_signal_single_point(self._handle, num_signals)
@@ -61,14 +61,14 @@ class SinglePointOutSignals(Signals):
 
     def write(
             self,
-            value_buffer):
+            signals):
         # type: (typing.Iterable[float]) -> None
         """Write data to a Signal Output Single-Point session.
 
         Args:
-            value_buffer(list): A list of singal values (float).
+            signals(list of float): A list of signal values (float).
         """
-        _funcs.nx_write_signal_single_point(self._handle, list(value_buffer))
+        _funcs.nx_write_signal_single_point(self._handle, list(signals))
 
 
 class Signal(collection.Item):

--- a/tests/test_signals.py
+++ b/tests/test_signals.py
@@ -22,38 +22,6 @@ def nixnet_out_interface(request):
 
 
 @pytest.mark.integration
-def test_singlepoint_loopback(nixnet_in_interface, nixnet_out_interface):
-    database_name = 'NIXNET_example'
-    cluster_name = 'CAN_Cluster'
-    signal_names = ['CANEventSignal1', 'CANEventSignal2']
-
-    with nixnet.SignalInSinglePointSession(
-            nixnet_in_interface,
-            database_name,
-            cluster_name,
-            signal_names) as input_session:
-        with nixnet.SignalOutSinglePointSession(
-                nixnet_out_interface,
-                database_name,
-                cluster_name,
-                signal_names) as output_session:
-            # Start the input session manually to make sure that the first
-            # frame value sent before the initial read will be received.
-            input_session.start()
-
-            expected_signals = [24.5343, 77.0129]
-            output_session.signals.write(expected_signals)
-
-            # Wait 1 s and then read the received values.
-            # They should be the same as the ones sent.
-            time.sleep(1)
-
-            actual_signals = list(input_session.signals.read())
-            for expected, (_, actual) in zip(expected_signals, actual_signals):
-                assert pytest.approx(expected, rel=1) == actual
-
-
-@pytest.mark.integration
 def test_signals_container(nixnet_in_interface):
     database_name = 'NIXNET_example'
     cluster_name = 'CAN_Cluster'
@@ -86,3 +54,35 @@ def test_signals_container(nixnet_in_interface):
         assert signal == input_session.signals.get(signal_name)
         assert input_session.signals.get(1) is None
         assert input_session.signals.get("<random>") is None
+
+
+@pytest.mark.integration
+def test_singlepoint_loopback(nixnet_in_interface, nixnet_out_interface):
+    database_name = 'NIXNET_example'
+    cluster_name = 'CAN_Cluster'
+    signal_names = ['CANEventSignal1', 'CANEventSignal2']
+
+    with nixnet.SignalInSinglePointSession(
+            nixnet_in_interface,
+            database_name,
+            cluster_name,
+            signal_names) as input_session:
+        with nixnet.SignalOutSinglePointSession(
+                nixnet_out_interface,
+                database_name,
+                cluster_name,
+                signal_names) as output_session:
+            # Start the input session manually to make sure that the first
+            # frame value sent before the initial read will be received.
+            input_session.start()
+
+            expected_signals = [24.5343, 77.0129]
+            output_session.signals.write(expected_signals)
+
+            # Wait 1 s and then read the received values.
+            # They should be the same as the ones sent.
+            time.sleep(1)
+
+            actual_signals = list(input_session.signals.read())
+            for expected, (_, actual) in zip(expected_signals, actual_signals):
+                assert pytest.approx(expected, rel=1) == actual


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nixnet-python/blob/master/CONTRIBUTING.rst).
- [x] New tests have been created for any new features or regression tests for bugfixes.
- [x] `tox` successfully runs, including unit tests and style checks (see [CONTRIBUTING.md](https://github.com/ni/nixnet-python/blob/master/CONTRIBUTING.rst)).