### PR TITLE
perf: Don't pre-allocate memory

### DIFF
--- a/nixnet/_session/signals.py
+++ b/nixnet/_session/signals.py
@@ -4,6 +4,8 @@ from __future__ import print_function
 
 import typing  # NOQA: F401
 
+import six
+
 from nixnet import _funcs
 from nixnet import _props
 
@@ -49,7 +51,7 @@ class SinglePointInSignals(Signals):
         """
         num_signals = len(self)
         timestamps, values = _funcs.nx_read_signal_single_point(self._handle, num_signals)
-        for timestamp, value in zip(timestamps, values):
+        for timestamp, value in six.moves.zip(timestamps, values):
             yield timestamp.value, value.value
 
 

--- a/nixnet/convert.py
+++ b/nixnet/convert.py
@@ -6,6 +6,8 @@ import itertools
 import typing  # NOQA: F401
 import warnings
 
+import six
+
 from nixnet import _frames
 from nixnet import _funcs
 from nixnet import _props
@@ -176,7 +178,7 @@ class SignalConversionSinglePointSession(object):
         # type: (bytes) -> typing.Iterable[typing.Tuple[int, float]]
         num_signals = len(self.signals)
         timestamps, values = _funcs.nx_convert_frames_to_signals_single_point(self._handle, bytes, num_signals)
-        for timestamp, value in zip(timestamps, values):
+        for timestamp, value in six.moves.zip(timestamps, values):
             yield timestamp.value, value.value
 
     def convert_frames_to_signals(self, frames):


### PR DESCRIPTION
No one will probably notice the difference.  Oh well.

- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nixnet-python/blob/master/CONTRIBUTING.rst).
- [x] New tests have been created for any new features or regression tests for bugfixes.
- [x] `tox` successfully runs, including unit tests and style checks (see [CONTRIBUTING.md](https://github.com/ni/nixnet-python/blob/master/CONTRIBUTING.rst)).