### PR TITLE
fix(examples): Improve reporting of frames (+ other stuff)

### DIFF
--- a/nixnet/session.py
+++ b/nixnet/session.py
@@ -312,7 +312,7 @@ class FrameOutQueuedSession(base.SessionBase):
     @property
     def frames(self):
         # type: () -> session_frames.OutFrames
-        """:any:`nixnet._session.frames.InFrames`: Operate on session's frames"""
+        """:any:`nixnet._session.frames.OutFrames`: Operate on session's frames"""
         return self._frames
 
 

--- a/nixnet/types.py
+++ b/nixnet/types.py
@@ -271,14 +271,24 @@ class RawFrame(Frame):
         """RawFrame debug representation.
 
         >>> RawFrame(1, 2, constants.FrameType.CAN_DATA, 3, 4)
-        RawFrame(timestamp=0x1, identifier=0x2, type=FrameType.CAN_DATA, flags=0x3, info=0x4, payload=...)
+        RawFrame(timestamp=0x1, identifier=0x2, type=FrameType.CAN_DATA, flags=0x3, info=0x4)
         """
-        return "RawFrame(timestamp=0x{:x}, identifier=0x{:x}, type={}, flags=0x{:x}, info=0x{:x}, payload=...)".format(
+        optional = []
+        if self.flags != 0:
+            optional.append('flags=0x{:x}'.format(self.flags))
+        if self.info != 0:
+            optional.append('info=0x{:x}'.format(self.info))
+        if self.payload:
+            optional.append('len(payload)={}'.format(len(self.payload)))
+        if optional:
+            optional_params = ', {}'.format(", ".join(optional))
+        else:
+            optional_params = ''
+        return "RawFrame(timestamp=0x{:x}, identifier=0x{:x}, type={}{})".format(
             self.timestamp,
             self.identifier,
             self.type,
-            self.flags,
-            self.info)
+            optional_params)
 
 
 class CanFrame(Frame):
@@ -317,7 +327,7 @@ class CanFrame(Frame):
 
         >>> raw = RawFrame(5, 0x20000001, constants.FrameType.CAN_DATA, _cconsts.NX_FRAME_FLAGS_TRANSMIT_ECHO, 0, b'')
         >>> CanFrame.from_raw(raw)
-        CanFrame(CanIdentifier(0x1, extended=True), echo=True, type=FrameType.CAN_DATA, timestamp=0x5, payload=...)
+        CanFrame(CanIdentifier(0x1, extended=True), echo=True, timestamp=0x5)
         """
         identifier = CanIdentifier.from_raw(frame.identifier)
         can_frame = CanFrame(identifier, constants.FrameType(frame.type), frame.payload)
@@ -329,11 +339,11 @@ class CanFrame(Frame):
         """Convert to RawFrame.
 
         >>> CanFrame(CanIdentifier(1, True), constants.FrameType.CAN_DATA).to_raw()
-        RawFrame(timestamp=0x0, identifier=0x20000001, type=FrameType.CAN_DATA, flags=0x0, info=0x0, payload=...)
+        RawFrame(timestamp=0x0, identifier=0x20000001, type=FrameType.CAN_DATA)
         >>> c = CanFrame(CanIdentifier(1, True), constants.FrameType.CAN_DATA)
         >>> c.echo = True
         >>> c.to_raw()
-        RawFrame(timestamp=0x0, identifier=0x20000001, type=FrameType.CAN_DATA, flags=0x80, info=0x0, payload=...)
+        RawFrame(timestamp=0x0, identifier=0x20000001, type=FrameType.CAN_DATA, flags=0x80)
         """
         identifier = int(self.identifier)
         flags = 0
@@ -361,14 +371,27 @@ class CanFrame(Frame):
         # type: () -> typing.Text
         """CanFrame debug representation.
 
-        >>> CanFrame(1, constants.FrameType.CAN_DATA)
-        CanFrame(CanIdentifier(0x1), echo=False, type=FrameType.CAN_DATA, timestamp=0x0, payload=...)
+        >>> CanFrame(1)
+        CanFrame(CanIdentifier(0x1))
+        >>> CanFrame(1, constants.FrameType.CANFD_DATA, b'\x01')
+        CanFrame(CanIdentifier(0x1), type=FrameType.CANFD_DATA, len(payload)=1)
         """
-        return "CanFrame({}, echo={}, type={}, timestamp=0x{:x}, payload=...)".format(
+        optional = []
+        if self.echo:
+            optional.append('echo={}'.format(self.echo))
+        if self.type != constants.FrameType.CAN_DATA:
+            optional.append('type={}'.format(self.type))
+        if self.timestamp != 0:
+            optional.append('timestamp=0x{:x}'.format(self.timestamp))
+        if self.payload:
+            optional.append('len(payload)={}'.format(len(self.payload)))
+        if optional:
+            optional_params = ', {}'.format(", ".join(optional))
+        else:
+            optional_params = ''
+        return "CanFrame({}{})".format(
             self.identifier,
-            self.echo,
-            self.type,
-            self.timestamp)
+            optional_params)
 
 
 class CanBusErrorFrame(Frame):
@@ -423,7 +446,7 @@ class CanBusErrorFrame(Frame):
         """Convert to RawFrame.
 
         >>> CanBusErrorFrame(100, constants.CanCommState.BUS_OFF, True, constants.CanLastErr.STUFF, 1, 2).to_raw()
-        RawFrame(timestamp=0x64, identifier=0x0, type=FrameType.CAN_BUS_ERROR, flags=0x0, info=0x0, payload=...)
+        RawFrame(timestamp=0x64, identifier=0x0, type=FrameType.CAN_BUS_ERROR, len(payload)=5)
         """
         identifier = 0
         flags = 0
@@ -503,7 +526,7 @@ class DelayFrame(Frame):
         """Convert to RawFrame.
 
         >>> DelayFrame(250).to_raw()
-        RawFrame(timestamp=0xfa, identifier=0x0, type=FrameType.SPECIAL_DELAY, flags=0x0, info=0x0, payload=...)
+        RawFrame(timestamp=0xfa, identifier=0x0, type=FrameType.SPECIAL_DELAY)
         """
         identifier = 0
         flags = 0
@@ -567,7 +590,7 @@ class LogTriggerFrame(Frame):
         """Convert to RawFrame.
 
         >>> LogTriggerFrame(250).to_raw()
-        RawFrame(timestamp=0xfa, identifier=0x0, type=FrameType.SPECIAL_LOG_TRIGGER, flags=0x0, info=0x0, payload=...)
+        RawFrame(timestamp=0xfa, identifier=0x0, type=FrameType.SPECIAL_LOG_TRIGGER)
         """
         identifier = 0
         flags = 0
@@ -627,7 +650,7 @@ class StartTriggerFrame(Frame):
         """Convert to RawFrame.
 
         >>> StartTriggerFrame(250).to_raw()
-        RawFrame(timestamp=0xfa, identifier=0x0, type=FrameType.SPECIAL_START_TRIGGER, flags=0x0, info=0x0, payload=...)
+        RawFrame(timestamp=0xfa, identifier=0x0, type=FrameType.SPECIAL_START_TRIGGER)
         """
         identifier = 0
         flags = 0

--- a/nixnet/types.py
+++ b/nixnet/types.py
@@ -459,7 +459,7 @@ class CanBusErrorFrame(Frame):
             self.tx_err_count,
             self.rx_err_count,
         ]
-        payload = bytes(payload_data)
+        payload = bytes(bytearray(payload_data))
         return RawFrame(self.timestamp, identifier, self.type, flags, info, payload)
 
     @property

--- a/nixnet/types.py
+++ b/nixnet/types.py
@@ -231,7 +231,7 @@ class RawFrame(Frame):
         "info",
         "payload"]
 
-    def __init__(self, timestamp, identifier, type, flags, info, payload=b""):
+    def __init__(self, timestamp, identifier, type, flags=0, info=0, payload=b""):
         # type: (int, int, constants.FrameType, int, int, bytes) -> None
         self.timestamp = timestamp
         self.identifier = identifier
@@ -300,7 +300,7 @@ class CanFrame(Frame):
         "timestamp",
         "payload"]
 
-    def __init__(self, identifier, type, payload=b""):
+    def __init__(self, identifier, type=constants.FrameType.CAN_DATA, payload=b""):
         # type: (typing.Union[CanIdentifier, int], constants.FrameType, bytes) -> None
         if isinstance(identifier, int):
             self.identifier = CanIdentifier(identifier)

--- a/nixnet_examples/can_frame_queued_io.py
+++ b/nixnet_examples/can_frame_queued_io.py
@@ -2,16 +2,13 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import pprint
-import six
 import time
+
+import six
 
 import nixnet
 from nixnet import constants
 from nixnet import types
-
-
-pp = pprint.PrettyPrinter(indent=4)
 
 
 def main():
@@ -75,8 +72,8 @@ def main():
                 count = 1
                 frames = input_session.frames.read(count)
                 for frame in frames:
-                    print('Received frame: ')
-                    pp.pprint(frame)
+                    print('Received frame: {}'.format(frame))
+                    print('    payload={}'.format(list(six.iterbytes(frame.payload))))
 
                 i += 1
                 if max(payload) + i > 0xFF:

--- a/nixnet_examples/can_frame_stream_io.py
+++ b/nixnet_examples/can_frame_stream_io.py
@@ -2,16 +2,13 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import pprint
-import six
 import time
+
+import six
 
 import nixnet
 from nixnet import constants
 from nixnet import types
-
-
-pp = pprint.PrettyPrinter(indent=4)
 
 
 def main():
@@ -67,8 +64,8 @@ def main():
                 count = 1
                 frames = input_session.frames.read(count)
                 for frame in frames:
-                    print('Received frame: ')
-                    pp.pprint(frame)
+                    print('Received frame: {}'.format(frame))
+                    print('    payload={}'.format(list(six.iterbytes(frame.payload))))
 
                 i += 1
                 if max(payload) + i > 0xFF:

--- a/nixnet_examples/can_signal_conversion.py
+++ b/nixnet_examples/can_signal_conversion.py
@@ -2,13 +2,9 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import pprint
 import six
 
 from nixnet import convert
-
-
-pp = pprint.PrettyPrinter(indent=4)
 
 
 def main():
@@ -35,12 +31,11 @@ def main():
         frames = session.convert_signals_to_frames(expected_signals)
         print('Frames:')
         for frame in frames:
-            print('    {}'.format(pp.pformat(frame)))
+            print('    {}'.format(frame))
+            print('        payload={}'.format(list(six.iterbytes(frame.payload))))
 
         converted_signals = session.convert_frames_to_signals(frames)
-        print('Signals:')
-        for expected, (_, converted) in zip(expected_signals, converted_signals):
-            print('    {} {}'.format(expected, converted))
+        print('Signals: {}'.format([v for (_, v) in converted_signals]))
 
 
 if __name__ == '__main__':

--- a/nixnet_examples/can_signal_single_point_io.py
+++ b/nixnet_examples/can_signal_single_point_io.py
@@ -3,16 +3,13 @@ from __future__ import division
 from __future__ import print_function
 
 import datetime
-import pprint
-import six
 import sys
 import time
 
+import six
+
 import nixnet
 from nixnet import constants
-
-
-pp = pprint.PrettyPrinter(indent=4)
 
 
 def convert_timestamp(timestamp):

--- a/nixnet_examples/can_signal_single_point_io.py
+++ b/nixnet_examples/can_signal_single_point_io.py
@@ -84,7 +84,7 @@ def main():
                 signals = input_session.signals.read()
                 for timestamp, value in signals:
                     date = convert_timestamp(timestamp)
-                    print('Received signal with timepstamp {} and value {}'.format(date, value))
+                    print('Received signal with timestamp {} and value {}'.format(date, value))
 
                 i += 1
                 if max(value_buffer) + i > sys.float_info.max:

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+import copy
 import mock  # type: ignore
 
 import pytest  # type: ignore
@@ -31,6 +32,8 @@ MockXnetLibrary.nx_clear.return_value = _ctypedefs.u32(0)
 
 
 def six_input(queue):
+    # Leave `input_values` alone for easier debugging
+    queue = copy.copy(queue)
     queue.reverse()
 
     def _six_input(prompt=""):

--- a/tests/test_frames.py
+++ b/tests/test_frames.py
@@ -35,7 +35,7 @@ def test_iterate_frames_with_empty_payload():
     payload = b'\x00\x00\x00\x00\x00\x00\x00\x00'
     empty_bytes = b'\x01\x00\x00\x00\x00\x00\x00\x00\x02\x00\x00\x00\x00\x04\x05\x00' + payload
     (empty_frame, ) = list(_frames.iterate_frames(empty_bytes))
-    assert repr(empty_frame) == 'RawFrame(timestamp=0x1, identifier=0x2, type=FrameType.CAN_DATA, flags=0x4, info=0x5, payload=...)'  # NOQA: E501
+    assert repr(empty_frame) == 'RawFrame(timestamp=0x1, identifier=0x2, type=FrameType.CAN_DATA, flags=0x4, info=0x5)'
     assert empty_frame.payload == b''
 
 
@@ -43,14 +43,14 @@ def test_iterate_frames_with_base_payload():
     payload = b'\x01\x02\x03\x04\x05\x06\x07\x08'
     base_bytes = b'\x06\x00\x00\x00\x00\x00\x00\x00\x07\x00\x00\x00\x00\x08\x09\x08' + payload
     (base_frame, ) = list(_frames.iterate_frames(base_bytes))
-    assert repr(base_frame) == 'RawFrame(timestamp=0x6, identifier=0x7, type=FrameType.CAN_DATA, flags=0x8, info=0x9, payload=...)'  # NOQA: E501
+    assert repr(base_frame) == 'RawFrame(timestamp=0x6, identifier=0x7, type=FrameType.CAN_DATA, flags=0x8, info=0x9, len(payload)=8)'  # NOQA: E501
     assert base_frame.payload == b'\x01\x02\x03\x04\x05\x06\x07\x08'
 
 
 def test_iterate_frames_with_partial_base_payload():
     frame_bytes = b'\xd8\xb7@B\xeb\xff\xd2\x01\x00\x00\x00\x00\x00\x00\x00\x04\x02\x04\x08\x10\x00\x00\x00\x00'
     (frame, ) = list(_frames.iterate_frames(frame_bytes))
-    assert repr(frame) == 'RawFrame(timestamp=0x1d2ffeb4240b7d8, identifier=0x0, type=FrameType.CAN_DATA, flags=0x0, info=0x0, payload=...)'  # NOQA: E501
+    assert repr(frame) == 'RawFrame(timestamp=0x1d2ffeb4240b7d8, identifier=0x0, type=FrameType.CAN_DATA, len(payload)=4)'  # NOQA: E501
     assert frame.payload == b'\x02\x04\x08\x10'
 
 


### PR DESCRIPTION
This mostly focuses on fixing #170. 
- Improve the frame repr
- Print payloads in examples

Some other minor fixes are done while at it.

- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nixnet-python/blob/master/CONTRIBUTING.rst).
- [x] New tests have been created for any new features or regression tests for bugfixes.
- [x] `tox` successfully runs, including unit tests and style checks (see [CONTRIBUTING.md](https://github.com/ni/nixnet-python/blob/master/CONTRIBUTING.rst)).