### PR TITLE
fix(API): Remove irrelevant resamp_rate property

### DIFF
--- a/nixnet/_session/signals.py
+++ b/nixnet/_session/signals.py
@@ -5,7 +5,6 @@ from __future__ import print_function
 import typing  # NOQA: F401
 
 from nixnet import _funcs
-from nixnet import _props
 
 from nixnet._session import collection
 
@@ -18,20 +17,6 @@ class Signals(collection.Collection):
 
     def _create_item(self, handle, index, name):
         return Signal(handle, index, name)
-
-    @property
-    def resamp_rate(self):
-        # type: () -> float
-        """float: Rate used to resample frame data to/from signal data in waveforms.
-
-        The units are in Hertz (samples per second).
-        """
-        return _props.get_session_resamp_rate(self._handle)
-
-    @resamp_rate.setter
-    def resamp_rate(self, value):
-        # type: (float) -> None
-        _props.set_session_resamp_rate(self._handle, value)
 
 
 class SinglePointInSignals(Signals):


### PR DESCRIPTION
This is only relevant to SignalsWaveform and will be re-added by #161.

Fixes #121.

BREAKING CHANGE: `session.signals` no longer has a `resamp_rate` property.
This never worked anyways so it shouldn't impact anyone.

- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nixnet-python/blob/master/CONTRIBUTING.rst).
- [x] New tests have been created for any new features or regression tests for bugfixes.
- [x] `tox` successfully runs, including unit tests and style checks (see [CONTRIBUTING.md](https://github.com/ni/nixnet-python/blob/master/CONTRIBUTING.rst)).