### PR TITLE
feat(API): Support LIN interface properties

### DIFF
--- a/nixnet/_enums.py
+++ b/nixnet/_enums.py
@@ -1400,6 +1400,35 @@ class FlexRayPocState(enum.Enum):
 
 
 class LinCommState(enum.Enum):
+    '''LIN Comm State
+
+    Values:
+        IDLE:
+            This is the LIN interface initial state on power-up. The
+            interface is essentially off, in that it is not attempting to
+            communicate with other nodes (ECUs). When the start trigger
+            occurs for the LIN interface, it transitions from the Idle
+            state to the Active state. When the interface stops due to a
+            call to XNET Stop, the LIN interface transitions from either
+            Active or Inactive to the Idle state.
+        ACTIVE:
+            This state reflects normal communication. The LIN interface remains
+            in this state as long as bus activity is detected (frame headers
+            received or transmitted).
+        INACTIVE:
+            This state indicates that no bus activity has been detected in the
+            past four seconds.
+
+            Regardless of whether the interface acts as a master or slave, it
+            transitions to this state after four seconds of bus inactivity. As
+            soon as bus activity is detected (break or frame header), the
+            interface transitions to the Active state.
+
+            The LIN interface does not go to sleep automatically when it
+            transitions to Inactive. To place the interface into sleep mode,
+            set the XNET Session Interface:LIN:Sleep property when you detect
+            the Inactive state.
+    '''
     IDLE = _cconsts.NX_LIN_COMM_STATE_IDLE
     ACTIVE = _cconsts.NX_LIN_COMM_STATE_ACTIVE
     INACTIVE = _cconsts.NX_LIN_COMM_STATE_INACTIVE
@@ -1468,6 +1497,28 @@ class LinDiagnosticSchedule(enum.Enum):
 
 
 class LinLastErrCode(enum.Enum):
+    '''LIN Comm Last Error Code
+
+    Values:
+        NONE:
+            No bus error has occurred since the previous communication state read.
+        UNKNOWN_ID:
+            Received a frame identifier that is not valid.
+        FORM:
+            The form of a received frame is incorrect. For example, the
+            database specifies 8 bytes of payload, but you receive only 4
+            bytes.
+        FRAMING:
+            The byte framing is incorrect (for example, a missing stop bit).
+        READBACK:
+            The interface transmitted a byte, but the value read back from the
+            transceiver was different. This often is caused by a cabling
+            problem, such as noise.
+        TIMEOUT:
+            Receiving the frame took longer than the LIN-specified timeout.
+        CRC:
+            The received checksum was different than the expected checksum.
+    '''
     NONE = _cconsts.NX_LIN_LAST_ERR_CODE_NONE
     UNKNOWN_ID = _cconsts.NX_LIN_LAST_ERR_CODE_UNKNOWN_ID
     FORM = _cconsts.NX_LIN_LAST_ERR_CODE_FORM

--- a/nixnet/_enums.py
+++ b/nixnet/_enums.py
@@ -1496,7 +1496,7 @@ class LinDiagnosticSchedule(enum.Enum):
     SLAVE_RESP = _cconsts.NX_LIN_DIAGNOSTIC_SCHEDULE_SLAVE_RESP
 
 
-class LinLastErrCode(enum.Enum):
+class LinLastErr(enum.Enum):
     '''LIN Comm Last Error Code
 
     Values:

--- a/nixnet/_enums.py
+++ b/nixnet/_enums.py
@@ -1729,6 +1729,20 @@ class FlexRayTerm(enum.Enum):
 
 
 class LinSleep(enum.Enum):
+    '''LIN interface sleep/awake state
+
+    Values:
+        REMOTE_SLEEP:
+            Set interface to sleep locally and transmit sleep requests to
+            remote node.
+        REMOTE_WAKE:
+            Set interface to awake locally and transmit wakeup requests to
+            remote nodes.
+        LOCAL_SLEEP:
+            Set interface to sleep locally and not to interact with the network.
+        LOCAL_WAKE:
+            Set interface to awake locally and not to interact with the network.
+    '''
     REMOTE_SLEEP = _cconsts.NX_LIN_SLEEP_REMOTE_SLEEP
     REMOTE_WAKE = _cconsts.NX_LIN_SLEEP_REMOTE_WAKE
     LOCAL_SLEEP = _cconsts.NX_LIN_SLEEP_LOCAL_SLEEP
@@ -1736,6 +1750,7 @@ class LinSleep(enum.Enum):
 
 
 class LinTerm(enum.Enum):
+    '''LIN Termination'''
     OFF = _cconsts.NX_LIN_TERM_OFF
     ON = _cconsts.NX_LIN_TERM_ON
 

--- a/nixnet/_funcs.py
+++ b/nixnet/_funcs.py
@@ -141,23 +141,22 @@ def nx_read_signal_single_point(
 def nx_read_state(
     session_ref,  # type: int
     state_id,  # type: _enums.ReadState
-    t,  # type: typing.Any
+    state_value_ctypes_ptr,  # type: typing.Any
 ):
     # type: (...) -> typing.Tuple[typing.Any, int]
     session_ref_ctypes = _ctypedefs.nxSessionRef_t(session_ref)
     state_id_ctypes = _ctypedefs.u32(state_id.value)
-    state_size_ctypes = _ctypedefs.u32(t.BYTES)
-    state_value_ctypes = t()
+    state_size_ctypes = _ctypedefs.u32(ctypes.sizeof(state_value_ctypes_ptr))
     fault_ctypes = _ctypedefs.nxStatus_t()
     result = _cfuncs.lib.nx_read_state(
         session_ref_ctypes,
         state_id_ctypes,
         state_size_ctypes,
-        ctypes.pointer(state_value_ctypes),
+        state_value_ctypes_ptr,
         ctypes.pointer(fault_ctypes),
     )
     _errors.check_for_error(result.value)
-    return state_value_ctypes.value, fault_ctypes.value
+    return fault_ctypes.value
 
 
 def nx_write_frame(

--- a/nixnet/_props.py
+++ b/nixnet/_props.py
@@ -1384,7 +1384,7 @@ def set_session_intf_lin_term(
     )
 
 
-def get_session_intf_lin_diag_p_2min(
+def get_session_intf_lin_diag_p2min(
     ref,  # type: int
 ):
     # type: (...) -> float
@@ -1394,7 +1394,7 @@ def get_session_intf_lin_diag_p_2min(
     )
 
 
-def set_session_intf_lin_diag_p_2min(
+def set_session_intf_lin_diag_p2min(
     ref,  # type: int
     value,  # type: float
 ):
@@ -1406,7 +1406,7 @@ def set_session_intf_lin_diag_p_2min(
     )
 
 
-def get_session_intf_lin_diag_s_tmin(
+def get_session_intf_lin_diag_stmin(
     ref,  # type: int
 ):
     # type: (...) -> float
@@ -1416,7 +1416,7 @@ def get_session_intf_lin_diag_s_tmin(
     )
 
 
-def set_session_intf_lin_diag_s_tmin(
+def set_session_intf_lin_diag_stmin(
     ref,  # type: int
     value,  # type: float
 ):
@@ -1450,7 +1450,7 @@ def set_session_intf_lin_alw_start_wo_bus_pwr(
     )
 
 
-def get_session_intf_lino_str_slv_rsp_lst_by_nad(
+def get_session_intf_lin_ostr_slv_rsp_lst_by_nad(
     ref,  # type: int
 ):
     # type: (...) -> typing.Iterable[int]
@@ -1460,7 +1460,7 @@ def get_session_intf_lino_str_slv_rsp_lst_by_nad(
     )
 
 
-def set_session_intf_lino_str_slv_rsp_lst_by_nad(
+def set_session_intf_lin_ostr_slv_rsp_lst_by_nad(
     ref,  # type: int
     value,  # type: typing.List[int]
 ):

--- a/nixnet/_session/base.py
+++ b/nixnet/_session/base.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+import ctypes  # type: ignore
 import typing  # NOQA: F401
 import warnings
 
@@ -374,14 +375,24 @@ class SessionBase(object):
     def time_current(self):
         # type: () -> int
         """int: Current interface time."""
-        time, _ = _funcs.nx_read_state(self._handle, constants.ReadState.TIME_CURRENT, _ctypedefs.nxTimestamp_t)
+        state_value_ctypes = _ctypedefs.nxTimestamp_t()
+        _funcs.nx_read_state(
+            self._handle,
+            constants.ReadState.TIME_CURRENT,
+            ctypes.pointer(state_value_ctypes))
+        time = state_value_ctypes.value
         return time
 
     @property
     def time_start(self):
         # type: () -> int
         """int: Time the interface was started."""
-        time, _ = _funcs.nx_read_state(self._handle, constants.ReadState.TIME_START, _ctypedefs.nxTimestamp_t)
+        state_value_ctypes = _ctypedefs.nxTimestamp_t()
+        _funcs.nx_read_state(
+            self._handle,
+            constants.ReadState.TIME_START,
+            ctypes.pointer(state_value_ctypes))
+        time = state_value_ctypes.value
         if time == 0:
             # The interface is not communicating.
             _errors.check_for_error(constants.Err.SESSION_NOT_STARTED.value)
@@ -395,7 +406,12 @@ class SessionBase(object):
         The time is usually later than ``time_start`` because the interface
         must undergo a communication startup procedure.
         """
-        time, _ = _funcs.nx_read_state(self._handle, constants.ReadState.TIME_COMMUNICATING, _ctypedefs.nxTimestamp_t)
+        state_value_ctypes = _ctypedefs.nxTimestamp_t()
+        _funcs.nx_read_state(
+            self._handle,
+            constants.ReadState.TIME_COMMUNICATING,
+            ctypes.pointer(state_value_ctypes))
+        time = state_value_ctypes.value
         if time == 0:
             # The interface is not communicating.
             _errors.check_for_error(constants.Err.SESSION_NOT_STARTED.value)
@@ -405,14 +421,24 @@ class SessionBase(object):
     def state(self):
         # type: () -> constants.SessionInfoState
         """:any:`nixnet._enums.SessionInfoState`: Session running state."""
-        state, _ = _funcs.nx_read_state(self._handle, constants.ReadState.SESSION_INFO, _ctypedefs.u32)
+        state_value_ctypes = _ctypedefs.u32()
+        _funcs.nx_read_state(
+            self._handle,
+            constants.ReadState.SESSION_INFO,
+            ctypes.pointer(state_value_ctypes))
+        state = state_value_ctypes.value
         return constants.SessionInfoState(state)
 
     @property
     def can_comm(self):
         # type: () -> types.CanComm
         """:any:`nixnet.types.CanComm`: CAN Communication state"""
-        bitfield, _ = _funcs.nx_read_state(self._handle, constants.ReadState.CAN_COMM, _ctypedefs.u32)
+        state_value_ctypes = _ctypedefs.u32()
+        _funcs.nx_read_state(
+            self._handle,
+            constants.ReadState.CAN_COMM,
+            ctypes.pointer(state_value_ctypes))
+        bitfield = state_value_ctypes.value
         return _utils.parse_can_comm_bitfield(bitfield)
 
     def check_fault(self):
@@ -427,7 +453,11 @@ class SessionBase(object):
         NI-XNET function calls, yet easy to use alongside the common practice
         of checking the communication state.
         """
-        _, fault = _funcs.nx_read_state(self._handle, constants.ReadState.SESSION_INFO, _ctypedefs.u32)
+        state_value_ctypes = _ctypedefs.u32()
+        fault = _funcs.nx_read_state(
+            self._handle,
+            constants.ReadState.SESSION_INFO,
+            ctypes.pointer(state_value_ctypes))
         _errors.check_for_error(fault)
 
     @property

--- a/nixnet/_session/base.py
+++ b/nixnet/_session/base.py
@@ -441,6 +441,19 @@ class SessionBase(object):
         bitfield = state_value_ctypes.value
         return _utils.parse_can_comm_bitfield(bitfield)
 
+    @property
+    def lin_comm(self):
+        # type: () -> types.LinComm
+        """:any:`nixnet.types.LinComm`: LIN Communication state"""
+        state_value_ctypes = (_ctypedefs.u32 * 2)()  # type: ignore
+        _funcs.nx_read_state(
+            self._handle,
+            constants.ReadState.LIN_COMM,
+            ctypes.pointer(state_value_ctypes))
+        first = state_value_ctypes[0].value
+        second = state_value_ctypes[1].value
+        return _utils.parse_lin_comm_bitfield(first, second)
+
     def check_fault(self):
         # type: () -> None
         """Check for an asynchronous fault.

--- a/nixnet/_session/intf.py
+++ b/nixnet/_session/intf.py
@@ -814,11 +814,12 @@ class Interface(object):
         the remote master to send a header for a frame in the output sessions,
         then the interface responds with data for the requested frame.
 
-        If you call the ``change_lin_sched`` function to request execution of a
+        If you call the :any:`nixnet._session.base.SessionBase.change_lin_schedule` function to request execution of a
         schedule, that implicitly sets this property to true (master). You also
-        can set this property to true using, but no schedule is
-        active by default, so you still must call the ``change_lin_sched`` function at
-        some point to request a specific schedule.
+        can set this property to true using, but no schedule is active by
+        default, so you still must call the
+        :any:`nixnet._session.base.SessionBase.change_lin_schedule` function at some
+        point to request a specific schedule.
 
         Regardless of this property's value, you use can input and output
         sessions. This property specifies which hardware transmits the
@@ -838,8 +839,9 @@ class Interface(object):
 
         List of schedules for use when the NI-XNET LIN interface acts as a
         master (``lin_master`` is true). When the interface is master, you can
-        pass the index of one of these schedules to the ``change_lin_sched``
-        function to request a schedule change.
+        pass the index of one of these schedules to the
+        :any:`nixnet._session.base.SessionBase.change_lin_schedule` function to request
+        a schedule change.
 
         This list of schedules is the same as ``Cluster.lin_schedules`` used to
         configure the session.

--- a/nixnet/_session/intf.py
+++ b/nixnet/_session/intf.py
@@ -768,16 +768,33 @@ class Interface(object):
 
     @property
     def lin_break_length(self):
+        # type: () -> int
+        '''int: LIN Break Length
+
+        The length of the serial break used at the start of a frame header
+        (schedule entry). The value is specified in bit-times.
+
+        The valid range is 10-36 (inclusive). The default value is 13, which is
+        the value the LIN standard specifies.
+
+        At baud rates below 9600, the upper limit may be lower than 36 to avoid
+        violating hold times for the bus. For example, at 2400 baud, the valid
+        range is 10-14.
+
+        .. note:: This property is applicable only when the interface is the
+           master.
+        '''
         return _props.get_session_intf_lin_break_length(self._handle)
 
     @lin_break_length.setter
     def lin_break_length(self, value):
+        # type: (int) -> None
         _props.set_session_intf_lin_break_length(self._handle, value)
 
     @property
     def lin_master(self):
         # type: () -> bool
-        '''boolean: LIN Master?
+        '''bool: LIN Master?
 
         Specifies the NI-XNET LIN interface role on the network: master (true)
         or slave (false).
@@ -785,77 +802,210 @@ class Interface(object):
         In a LIN network (cluster), there always is a single ECU in the system
         called the master. The master transmits a schedule of frame headers.
         Each frame header is a remote request for a specific frame ID. For each
-        header, typically a single ECU in the network (slave) responds by transmitting
-        the requested ID payload. The master ECU can respond to a specific header
-        as well, and thus the master can transmit payload data for the slave
-        ECUs to receive.
+        header, typically a single ECU in the network (slave) responds by
+        transmitting the requested ID payload. The master ECU can respond to a
+        specific header as well, and thus the master can transmit payload data
+        for the slave ECUs to receive.
 
-        The default value for this property is false (slave). This means that by
-        default, the interface does not transmit frame headers onto the network.
-        When you use input sessions, you read frames that other ECUs transmit.
-        When you use output sessions, the NI-XNET interface waits for the remote
-        master to send a header for a frame in the output sessions, then the interface
-        responds with data for the requested frame.
+        The default value for this property is false (slave). This means that
+        by default, the interface does not transmit frame headers onto the
+        network. When you use input sessions, you read frames that other ECUs
+        transmit. When you use output sessions, the NI-XNET interface waits for
+        the remote master to send a header for a frame in the output sessions,
+        then the interface responds with data for the requested frame.
+
+        If you call the ``change_lin_sched`` function to request execution of a
+        schedule, that implicitly sets this property to true (master). You also
+        can set this property to true using, but no schedule is
+        active by default, so you still must call the ``change_lin_sched`` function at
+        some point to request a specific schedule.
+
+        Regardless of this property's value, you use can input and output
+        sessions. This property specifies which hardware transmits the
+        scheduled frame headers: NI-XNET (true) or a remote master ECU (false).
         '''
         return _props.get_session_intf_lin_master(self._handle)
 
     @lin_master.setter
     def lin_master(self, value):
+        # type: (bool) -> None
         _props.set_session_intf_lin_master(self._handle, value)
 
     @property
     def lin_sched_names(self):
+        # type: () -> typing.Iterable[typing.Text]
+        '''list of str: LIN Schedule Names
+
+        List of schedules for use when the NI-XNET LIN interface acts as a
+        master (``lin_master`` is true). When the interface is master, you can
+        pass the index of one of these schedules to the ``change_lin_sched``
+        function to request a schedule change.
+
+        This list of schedules is the same as ``Cluster.lin_schedules`` used to
+        configure the session.
+        '''
         return _props.get_session_intf_lin_sched_names(self._handle)
 
-    def set_lin_sleep(self, value):
-        _props.set_session_intf_lin_sleep(self._handle, value.value)
+    def set_lin_sleep(self, state):
+        # type: (constants.LinSleep) -> None
+        '''Set LIN Sleep State
+
+        Use the Sleep property to change the NI-XNET LIN interface sleep/awake
+        state and optionally to change remote node (ECU) sleep/awake states.
+
+        .. note:: Setting a new value is effectively a request, and the
+           function returns before the request is complete.  To detect the
+           current interface sleep/wake state, use
+           :any:`nixnet._session.base.SessionBase.lin_comm`.
+
+        Args:
+            state(:any:`nixnet._enums.LinSleep`): Desired state.
+        '''
+        _props.set_session_intf_lin_sleep(self._handle, state.value)
 
     @property
     def lin_term(self):
+        # type: () -> constants.LinTerm
+        ''':any:`nixnet._enums.LinTerm`: LIN Termination
+
+        The Termination property configures the NI-XNET interface LIN connector
+        (port) onboard termination. The enumeration is generic and supports two
+        values: Off (disabled) and On (enabled).
+
+        Per the LIN 2.1 standard, the Master ECU has a ~1 kOhm termination
+        resistor between Vbat and Vbus. Therefore, use this property only if
+        you are using your interface as the master and do not already have
+        external termination.
+
+        .. note:: You can modify this property only when the interface is
+           stopped.
+        .. note:: This property does not take effect until the interface is
+           started.
+        '''
         return constants.LinTerm(_props.get_session_intf_lin_term(self._handle))
 
     @lin_term.setter
     def lin_term(self, value):
+        # type: (constants.LinTerm) -> None
         _props.set_session_intf_lin_term(self._handle, value.value)
 
     @property
-    def lin_diag_p_2min(self):
-        return _props.get_session_intf_lin_diag_p_2min(self._handle)
+    def lin_diag_p2min(self):
+        # type: () -> float
+        '''float: LIN Diag P2min
 
-    @lin_diag_p_2min.setter
-    def lin_diag_p_2min(self, value):
-        _props.set_session_intf_lin_diag_p_2min(self._handle, value)
+        This is the minimum time in seconds between reception of the last frame
+        of the diagnostic request message and transmission of the response for
+        the first frame in the diagnostic response message by the slave.
+
+        .. note:: This property applies only to the interface as slave.
+        '''
+        return _props.get_session_intf_lin_diag_p2min(self._handle)
+
+    @lin_diag_p2min.setter
+    def lin_diag_p2min(self, value):
+        # type: (float) -> None
+        _props.set_session_intf_lin_diag_p2min(self._handle, value)
 
     @property
-    def lin_diag_s_tmin(self):
-        return _props.get_session_intf_lin_diag_s_tmin(self._handle)
+    def lin_diag_stmin(self):
+        # type: () -> float
+        '''float: LIN Diag STmin
 
-    @lin_diag_s_tmin.setter
-    def lin_diag_s_tmin(self, value):
-        _props.set_session_intf_lin_diag_s_tmin(self._handle, value)
+        master:
+            The minimum time in seconds the interface places between the end of
+            transmission of a frame in a diagnostic request message and the
+            start of transmission of the next frame in the diagnostic request
+            message.
+        slave:
+            The minimum time in seconds the interface places between the end of
+            transmission of a frame in a diagnostic response message and the
+            start of transmission of the response for the next frame in the
+            diagnostic response message.
+        '''
+        return _props.get_session_intf_lin_diag_stmin(self._handle)
+
+    @lin_diag_stmin.setter
+    def lin_diag_stmin(self, value):
+        # type: (float) -> None
+        _props.set_session_intf_lin_diag_stmin(self._handle, value)
 
     @property
     def lin_alw_start_wo_bus_pwr(self):
+        # type: () -> bool
+        '''bool: LIN Start Allowed without Bus Power?
+
+        Configures whether the LIN interface does not check for bus power
+        present at interface start, or checks and reports an error if bus power
+        is missing.
+
+        When this property is true, the LIN interface does not check for bus
+        power present at start, so no error is reported if the interface is
+        started without bus power.
+
+        When this property is false, the LIN interface checks for bus power
+        present at start, and an error is reported if the interface
+        is started without bus power.
+
+        .. note:: You can modify this property only when the interface is
+           stopped.
+        '''
         return _props.get_session_intf_lin_alw_start_wo_bus_pwr(self._handle)
 
     @lin_alw_start_wo_bus_pwr.setter
     def lin_alw_start_wo_bus_pwr(self, value):
+        # type: (bool) -> None
         _props.set_session_intf_lin_alw_start_wo_bus_pwr(self._handle, value)
 
     @property
-    def lino_str_slv_rsp_lst_by_nad(self):
-        return _props.get_session_intf_lino_str_slv_rsp_lst_by_nad(self._handle)
+    def lin_ostr_slv_rsp_lst_by_nad(self):
+        # type: () -> typing.Iterable[int]
+        '''list of int: LIN Output Stream Slave Response List By NAD
 
-    @lino_str_slv_rsp_lst_by_nad.setter
-    def lino_str_slv_rsp_lst_by_nad(self, value):
-        _props.set_session_intf_lino_str_slv_rsp_lst_by_nad(self._handle, value)
+        A list of NADs for use with the replay feature
+        (:any:`nixnet._session.intf.Interface.out_strm_timng` set to Replay
+        Exclusive or Replay Inclusive).
+
+        For LIN, the array of frames to replay might contain multiple slave
+        response frames, each with the same slave response identifier, but each
+        having been transmitted by a different slave (per the NAD value in the
+        data payload). This means that processing slave response frames for
+        replay requires two levels of filtering. First, you can include or
+        exclude the slave response frame or ID for replay using
+        Interface:Output Stream List or Interface:Output Stream List By ID. If
+        you do not include the slave response frame or ID for replay, no slave
+        responses are transmitted. If you do include the slave response frame
+        or ID for replay, you can use the Output Stream Slave Response List by
+        NAD property to filter which slave responses (per the NAD values in the
+        array) are transmitted. This property is always inclusive, regardless
+        of the replay mode (inclusive or exclusive). If the NAD is in the list
+        and the response frame or ID has been enabled for replay, any slave
+        response for that NAD is transmitted. If the NAD is not in the list, no
+        slave response for that NAD is transmitted.
+        '''
+        return _props.get_session_intf_lin_ostr_slv_rsp_lst_by_nad(self._handle)
+
+    @lin_ostr_slv_rsp_lst_by_nad.setter
+    def lin_ostr_slv_rsp_lst_by_nad(self, value):
+        # type: (typing.List[int]) -> None
+        _props.set_session_intf_lin_ostr_slv_rsp_lst_by_nad(self._handle, value)
 
     @property
     def lin_no_response_to_in_strm(self):
+        # type: () -> bool
+        '''bool: LIN No Response Frames to Input Stream?
+
+        Configure the hardware to place a LIN no response frame into the
+        Stream Input queue after it is generated. A no response frame is
+        generated when the hardware detects a header with no response. For more
+        information about the no response frame, see
+        ``nixnet.types.NoResponseFrame``.
+        '''
         return _props.get_session_intf_lin_no_response_to_in_strm(self._handle)
 
     @lin_no_response_to_in_strm.setter
     def lin_no_response_to_in_strm(self, value):
+        # type: (bool) -> None
         _props.set_session_intf_lin_no_response_to_in_strm(self._handle, value)
 
     @property

--- a/nixnet/_utils.py
+++ b/nixnet/_utils.py
@@ -53,3 +53,27 @@ def parse_can_comm_bitfield(bitfield):
     tx_err_count = ((bitfield >> 16) & 0x0FF)
     rx_err_count = ((bitfield >> 24) & 0x0FF)
     return types.CanComm(state, tcvr_err, sleep, last_err, tx_err_count, rx_err_count)
+
+
+def parse_lin_comm_bitfield(first, second):
+    # (int) -> types.CanComm
+    """Parse a LIN Comm first."""
+    sleep = ((first >> 1) & 0x01) != 0
+    state = constants.LinCommState((first >> 2) & 0x03)
+    last_err = constants.LinLastErrCode((first >> 4) & 0x0F)
+    last_err_received = (first >> 8) & 0x0FF
+    last_err_expected = (first >> 16) & 0x0FF
+    last_err_id = (first >> 24) & 0x03F
+    tcvr_rdy = ((first >> 32) & 0x01) != 0
+
+    sched_index = second & 0x0FF
+
+    return types.LinComm(
+        sleep,
+        state,
+        last_err,
+        last_err_received,
+        last_err_expected,
+        last_err_id,
+        tcvr_rdy,
+        sched_index)

--- a/nixnet/_utils.py
+++ b/nixnet/_utils.py
@@ -60,7 +60,7 @@ def parse_lin_comm_bitfield(first, second):
     """Parse a LIN Comm first."""
     sleep = ((first >> 1) & 0x01) != 0
     state = constants.LinCommState((first >> 2) & 0x03)
-    last_err = constants.LinLastErrCode((first >> 4) & 0x0F)
+    last_err = constants.LinLastErr((first >> 4) & 0x0F)
     last_err_received = (first >> 8) & 0x0FF
     last_err_expected = (first >> 16) & 0x0FF
     last_err_id = (first >> 24) & 0x03F

--- a/nixnet/types.py
+++ b/nixnet/types.py
@@ -16,6 +16,7 @@ from nixnet import constants
 __all__ = [
     'DriverVersion',
     'CanComm',
+    'LinComm',
     'CanIdentifier',
     'FrameFactory',
     'Frame',
@@ -75,6 +76,63 @@ class CanComm(CanComm_):
             increases when a certain ratio of frames (roughly 1/8) encounter
             errors.
     """
+
+    pass
+
+
+LinComm_ = collections.namedtuple(
+    'LinComm_',
+    ['sleep', 'state', 'last_err', 'last_err_received', 'last_err_expected', 'last_err_id', 'tcvr_rdy', 'sched_index'])
+
+
+class LinComm(LinComm_):
+    """CAN Communication State.
+
+    Attributes:
+        sleep (bool): Sleep.
+            Indicates whether the transceiver and communication
+            controller are in their sleep state. False indicates normal
+            operation (awake), and true indicates sleep.
+        state (:any:`nixnet._enums.LinCommState`): Communication State
+        last_err (:any:`nixnet._enums.LinLastErrCode`): Last Error.
+            Last error specifies the status of the last attempt to receive or
+            transmit a frame
+        last_err_received (int): Returns the value received from the network
+            when last error occurred.
+
+            When ``last_err`` is ``READBACK``, this is the value read back.
+
+            When ``last_err`` is ``CHECKSUM``, this is the received checksum.
+        last_err_expected (int): Returns the value that the LIN interface
+            expected to see (instead of last received).
+
+            When ``last_err`` is ``READBACK``, this is the value transmitted.
+
+            When ``last_err`` is ``CHECKSUM``, this is the calculated checksum.
+        last_err_id (int): Returns the frame identifier in which the last error
+            occurred.
+
+            This is not applicable when ``last_err`` is ``NONE`` or ``UNKNOWN_ID``.
+        tcvr_rdy (bool): Indicates whether the LIN transceiver is powered from
+            the bus.
+
+            True indicates the bus power exists, so it is safe to start
+            communication on the LIN interface.
+
+            If this value is false, you cannot start communication
+            successfully. Wire power to the LIN transceiver and run your
+            application again.
+        sched_index (int): Indicates the LIN schedule that the interface
+            currently is running.
+
+            This index refers to a LIN schedule that you requested using the
+            ``change_lin_sched`` function. It indexes the array of schedules
+            represented in the :any:`nixnet._session.intf.Interface.lin_sched_names`.
+
+            This index applies only when the LIN interface is running as a
+            master. If the LIN interface is running as a slave only, this
+            element should be ignored.
+        """
 
     pass
 

--- a/nixnet/types.py
+++ b/nixnet/types.py
@@ -24,6 +24,7 @@ __all__ = [
     'CanFrame',
     'CanBusErrorFrame',
     'LinFrame',
+    'LinBusErrorFrame',
     'DelayFrame',
     'LogTriggerFrame',
     'StartTriggerFrame',
@@ -82,7 +83,7 @@ class CanComm(CanComm_):
 
 LinComm_ = collections.namedtuple(
     'LinComm_',
-    ['sleep', 'state', 'last_err', 'last_err_received', 'last_err_expected', 'last_err_id', 'tcvr_rdy', 'sched_index'])
+    ['sleep', 'state', 'last_err', 'err_received', 'err_expected', 'err_id', 'tcvr_rdy', 'sched_index'])
 
 
 class LinComm(LinComm_):
@@ -94,22 +95,22 @@ class LinComm(LinComm_):
             controller are in their sleep state. False indicates normal
             operation (awake), and true indicates sleep.
         state (:any:`nixnet._enums.LinCommState`): Communication State
-        last_err (:any:`nixnet._enums.LinLastErrCode`): Last Error.
+        last_err (:any:`nixnet._enums.LinLastErr`): Last Error.
             Last error specifies the status of the last attempt to receive or
             transmit a frame
-        last_err_received (int): Returns the value received from the network
+        err_received (int): Returns the value received from the network
             when last error occurred.
 
             When ``last_err`` is ``READBACK``, this is the value read back.
 
             When ``last_err`` is ``CHECKSUM``, this is the received checksum.
-        last_err_expected (int): Returns the value that the LIN interface
+        err_expected (int): Returns the value that the LIN interface
             expected to see (instead of last received).
 
             When ``last_err`` is ``READBACK``, this is the value transmitted.
 
             When ``last_err`` is ``CHECKSUM``, this is the calculated checksum.
-        last_err_id (int): Returns the frame identifier in which the last error
+        err_id (int): Returns the frame identifier in which the last error
             occurred.
 
             This is not applicable when ``last_err`` is ``NONE`` or ``UNKNOWN_ID``.
@@ -688,6 +689,109 @@ class LinFrame(object):
         return "LinFrame(identifier=0x{:x}{})".format(
             self.identifier,
             optional_params)
+
+
+class LinBusErrorFrame(Frame):
+    """Error detected on hardware bus of a :any:`nixnet.session.FrameInStreamSession`.
+
+    .. note:: This requires enabling
+       :any:`nixnet._session.intf.Interface.bus_err_to_in_strm`.
+
+    See also :any:`nixnet.types.LinComm`.
+
+    Attributes:
+        timestamp(int): Absolute time when the bus error occurred.
+        state (:any:`nixnet._enums.LinCommState`): Communication State.
+        bus_err (:any:`nixnet._enums.LinLastErr`): Last Error.
+        err_id (int): Identifier on bus.
+        err_received (int): Received byte on bus
+        err_expected (int): Expected byte on bus
+    """
+
+    __slots__ = [
+        "timestamp",
+        "state",
+        "bus_err",
+        "err_id",
+        "err_received",
+        "err_expected"]
+
+    def __init__(self, timestamp, state, bus_err, err_id, err_received, err_expected):
+        # type: (int, constants.LinCommState, constants.LinLastErr, int, int, int) -> None
+        self.timestamp = timestamp
+        self.state = state
+        self.bus_err = bus_err
+        self.err_id = err_id
+        self.err_received = err_received
+        self.err_expected = err_expected
+
+    @classmethod
+    def from_raw(cls, frame):
+        """Convert from RawFrame.
+
+        >>> raw = RawFrame(0x64, 0x0, constants.FrameType.LIN_BUS_ERROR, 0, 0, b'\\x00\\x01\\x02\\x03\\x04')
+        >>> LinBusErrorFrame.from_raw(raw)
+        LinBusErrorFrame(0x64, LinCommState.IDLE, LinLastErr.UNKNOWN_ID, 0x2, 3, 4)
+        """
+        timestamp = frame.timestamp
+        state = constants.LinCommState(six.indexbytes(frame.payload, 0))
+        bus_err = constants.LinLastErr(six.indexbytes(frame.payload, 1))
+        err_id = six.indexbytes(frame.payload, 2)
+        err_received = six.indexbytes(frame.payload, 3)
+        err_expected = six.indexbytes(frame.payload, 4)
+        return LinBusErrorFrame(timestamp, state, bus_err, err_id, err_received, err_expected)
+
+    def to_raw(self):
+        """Convert to RawFrame.
+
+        >>> LinBusErrorFrame(100, constants.LinCommState.INACTIVE, constants.LinLastErr.UNKNOWN_ID, 2, 3, 4).to_raw()
+        RawFrame(timestamp=0x64, identifier=0x0, type=FrameType.LIN_BUS_ERROR, len(payload)=5)
+        """
+        identifier = 0
+        flags = 0
+        info = 0
+
+        payload_data = [
+            self.state.value,
+            self.bus_err.value,
+            self.err_id,
+            self.err_received,
+            self.err_expected,
+        ]
+        payload = bytes(bytearray(payload_data))
+        return RawFrame(self.timestamp, identifier, self.type, flags, info, payload)
+
+    @property
+    def type(self):
+        return constants.FrameType.LIN_BUS_ERROR
+
+    def __eq__(self, other):
+        if isinstance(other, self.__class__):
+            other_frame = typing.cast(LinBusErrorFrame, other)
+            return all((
+                self.timestamp == other_frame.timestamp,
+                self.state == other_frame.state,
+                self.bus_err == other_frame.bus_err,
+                self.err_id == other_frame.err_id,
+                self.err_received == other_frame.err_received,
+                self.err_expected == other_frame.err_expected))
+        else:
+            return NotImplemented
+
+    def __repr__(self):
+        # type: () -> typing.Text
+        """LinBusErrorFrame debug representation.
+
+        >>> LinBusErrorFrame(100, constants.LinCommState.INACTIVE, constants.LinLastErr.CRC, 1, 2, 3)
+        LinBusErrorFrame(0x64, LinCommState.INACTIVE, LinLastErr.CRC, 0x1, 2, 3)
+        """
+        return "LinBusErrorFrame(0x{:x}, {}, {}, 0x{:x}, {}, {})".format(
+            self.timestamp,
+            self.state,
+            self.bus_err,
+            self.err_id,
+            self.err_received,
+            self.err_expected)
 
 
 class DelayFrame(Frame):

--- a/nixnet/types.py
+++ b/nixnet/types.py
@@ -127,8 +127,9 @@ class LinComm(LinComm_):
             currently is running.
 
             This index refers to a LIN schedule that you requested using the
-            ``change_lin_sched`` function. It indexes the array of schedules
-            represented in the :any:`nixnet._session.intf.Interface.lin_sched_names`.
+            :any:`nixnet._session.base.SessionBase.change_lin_schedule` function. It
+            indexes the array of schedules represented in the
+            :any:`nixnet._session.intf.Interface.lin_sched_names`.
 
             This index applies only when the LIN interface is running as a
             master. If the LIN interface is running as a slave only, this

--- a/tests/test_frames.py
+++ b/tests/test_frames.py
@@ -182,6 +182,19 @@ def test_lin_frame_identifier_overflow():
         types.LinFrame(0xFFFFFFFF).to_raw()
 
 
+def test_lin_bus_error_frame_equality():
+    frame = types.LinBusErrorFrame(100, constants.LinCommState.IDLE, constants.LinLastErr.UNKNOWN_ID, 1, 2, 3)
+    other_frame = types.LinBusErrorFrame(100, constants.LinCommState.IDLE, constants.LinLastErr.UNKNOWN_ID, 1, 3, 3)
+
+    assert frame == frame
+    assert not (frame == other_frame)
+    assert not (frame == 5)
+
+    assert not (frame != frame)
+    assert frame != other_frame
+    assert frame != 5
+
+
 def test_delay_frame_equality():
     frame = types.DelayFrame(100)
     other_frame = types.DelayFrame(120)

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -15,13 +15,13 @@ from nixnet import types
 
 
 @pytest.fixture
-def nixnet_in_interface(request):
+def can_in_interface(request):
     interface = request.config.getoption("--can-in-interface")
     return interface
 
 
 @pytest.fixture
-def nixnet_out_interface(request):
+def can_out_interface(request):
     interface = request.config.getoption("--can-out-interface")
     return interface
 
@@ -39,9 +39,9 @@ def test_flatten_items_invalid():
 
 
 @pytest.mark.integration
-def test_session_container(nixnet_in_interface, nixnet_out_interface):
-    with nixnet.FrameInStreamSession(nixnet_in_interface) as input_session:
-        with nixnet.FrameInStreamSession(nixnet_out_interface) as output_session:
+def test_session_container(can_in_interface, can_out_interface):
+    with nixnet.FrameInStreamSession(can_in_interface) as input_session:
+        with nixnet.FrameInStreamSession(can_out_interface) as output_session:
             assert input_session == input_session
             assert not (input_session == output_session)
             assert not (input_session == 1)
@@ -59,7 +59,7 @@ def test_session_container(nixnet_in_interface, nixnet_out_interface):
 
 
 @pytest.mark.integration
-def test_session_properties(nixnet_out_interface):
+def test_session_properties(can_out_interface):
     """Verify Session properties.
 
     Ideally, mutable properties would be set to multiple values and we'd test
@@ -71,7 +71,7 @@ def test_session_properties(nixnet_out_interface):
     frame_name = 'CANEventFrame1'
 
     with nixnet.FrameOutQueuedSession(
-            nixnet_out_interface,
+            can_out_interface,
             database_name,
             cluster_name,
             frame_name) as output_session:
@@ -99,14 +99,14 @@ def test_session_properties(nixnet_out_interface):
 
 
 @pytest.mark.integration
-def test_session_properties_transition(nixnet_out_interface):
+def test_session_properties_transition(can_out_interface):
     """Verify Session properties relationship to session start/stop."""
     database_name = 'NIXNET_example'
     cluster_name = 'CAN_Cluster'
     frame_name = 'CANEventFrame1'
 
     with nixnet.FrameOutQueuedSession(
-            nixnet_out_interface,
+            can_out_interface,
             database_name,
             cluster_name,
             frame_name) as output_session:
@@ -189,7 +189,7 @@ def assert_can_frame(index, sent, received):
 
 
 @pytest.mark.integration
-def test_start_explicit(nixnet_in_interface, nixnet_out_interface):
+def test_start_explicit(can_in_interface, can_out_interface):
     """Demonstrate that data is properly sent out on an explicit start.
 
     Assumes test_frames.test_queued_loopback works
@@ -199,12 +199,12 @@ def test_start_explicit(nixnet_in_interface, nixnet_out_interface):
     frame_name = 'CANEventFrame1'
 
     with nixnet.FrameInQueuedSession(
-            nixnet_in_interface,
+            can_in_interface,
             database_name,
             cluster_name,
             frame_name) as input_session:
         with nixnet.FrameOutQueuedSession(
-                nixnet_out_interface,
+                can_out_interface,
                 database_name,
                 cluster_name,
                 frame_name) as output_session:
@@ -229,7 +229,7 @@ def test_start_explicit(nixnet_in_interface, nixnet_out_interface):
 
 
 @pytest.mark.integration
-def test_flush_baseline(nixnet_in_interface, nixnet_out_interface):
+def test_flush_baseline(can_in_interface, can_out_interface):
     """Demonstrate that the non-flush version of the code works.
 
     Assumes test_frames.test_queued_loopback works.
@@ -239,12 +239,12 @@ def test_flush_baseline(nixnet_in_interface, nixnet_out_interface):
     frame_name = 'CANEventFrame1'
 
     with nixnet.FrameInQueuedSession(
-            nixnet_in_interface,
+            can_in_interface,
             database_name,
             cluster_name,
             frame_name) as input_session:
         with nixnet.FrameOutQueuedSession(
-                nixnet_out_interface,
+                can_out_interface,
                 database_name,
                 cluster_name,
                 frame_name) as output_session:
@@ -273,7 +273,7 @@ def test_flush_baseline(nixnet_in_interface, nixnet_out_interface):
 
 
 @pytest.mark.integration
-def test_flush_output_queue(nixnet_in_interface, nixnet_out_interface):
+def test_flush_output_queue(can_in_interface, can_out_interface):
     """Verifies that `flush` drops frames in the output queue
 
     Assumes test_frames.test_queued_loopback works.
@@ -283,12 +283,12 @@ def test_flush_output_queue(nixnet_in_interface, nixnet_out_interface):
     frame_name = 'CANEventFrame1'
 
     with nixnet.FrameInQueuedSession(
-            nixnet_in_interface,
+            can_in_interface,
             database_name,
             cluster_name,
             frame_name) as input_session:
         with nixnet.FrameOutQueuedSession(
-                nixnet_out_interface,
+                can_out_interface,
                 database_name,
                 cluster_name,
                 frame_name) as output_session:
@@ -316,7 +316,7 @@ def test_flush_output_queue(nixnet_in_interface, nixnet_out_interface):
 
 
 @pytest.mark.integration
-def test_wait_for_intf_communicating(nixnet_in_interface):
+def test_wait_for_intf_communicating(can_in_interface):
     """Verifies wait_for_intf_communicating does not catastrophically fail.
 
     Considering the wait time is so short, it'd be hard to verify it,
@@ -329,7 +329,7 @@ def test_wait_for_intf_communicating(nixnet_in_interface):
     frame_name = 'CANEventFrame1'
 
     with nixnet.FrameInQueuedSession(
-            nixnet_in_interface,
+            can_in_interface,
             database_name,
             cluster_name,
             frame_name) as input_session:
@@ -344,7 +344,7 @@ def test_wait_for_intf_communicating(nixnet_in_interface):
 
 
 @pytest.mark.integration
-def test_wait_for_transmit_complete(nixnet_in_interface, nixnet_out_interface):
+def test_wait_for_transmit_complete(can_in_interface, can_out_interface):
     """Verifies wait_for_transmit_complete does not fail catastrophically.
 
     We can at least see how long it takes us to wait.  Longer term, we should
@@ -360,12 +360,12 @@ def test_wait_for_transmit_complete(nixnet_in_interface, nixnet_out_interface):
     frame_name = 'CANEventFrame1'
 
     with nixnet.FrameInQueuedSession(
-            nixnet_in_interface,
+            can_in_interface,
             database_name,
             cluster_name,
             frame_name) as input_session:
         with nixnet.FrameOutQueuedSession(
-                nixnet_out_interface,
+                can_out_interface,
                 database_name,
                 cluster_name,
                 frame_name) as output_session:
@@ -398,7 +398,7 @@ def test_wait_for_transmit_complete(nixnet_in_interface, nixnet_out_interface):
 
 
 @pytest.mark.integration
-def test_wait_for_intf_remote_wakeup(nixnet_in_interface, nixnet_out_interface):
+def test_wait_for_intf_remote_wakeup(can_in_interface, can_out_interface):
     """Verifies wait_for_intf_remote_wakeup does not fail catastrophically.
 
     We can at least see how long it takes us to wait.  Longer term, we should
@@ -414,7 +414,7 @@ def test_wait_for_intf_remote_wakeup(nixnet_in_interface, nixnet_out_interface):
     frame_name = 'CANEventFrame1'
 
     with nixnet.FrameInQueuedSession(
-            nixnet_in_interface,
+            can_in_interface,
             database_name,
             cluster_name,
             frame_name) as input_session:
@@ -431,14 +431,14 @@ def test_wait_for_intf_remote_wakeup(nixnet_in_interface, nixnet_out_interface):
 
 
 @pytest.mark.integration
-def test_connect_terminals_failures(nixnet_in_interface):
+def test_connect_terminals_failures(can_in_interface):
     """Verifies connect_terminals fails when expected to."""
     database_name = 'NIXNET_example'
     cluster_name = 'CAN_Cluster'
     frame_name = 'CANEventFrame1'
 
     with nixnet.FrameInQueuedSession(
-            nixnet_in_interface,
+            can_in_interface,
             database_name,
             cluster_name,
             frame_name) as input_session:
@@ -450,14 +450,14 @@ def test_connect_terminals_failures(nixnet_in_interface):
 
 
 @pytest.mark.integration
-def test_disconnect_terminals_failures(nixnet_in_interface):
+def test_disconnect_terminals_failures(can_in_interface):
     """Verifies disconnect_terminals fails when expected to."""
     database_name = 'NIXNET_example'
     cluster_name = 'CAN_Cluster'
     frame_name = 'CANEventFrame1'
 
     with nixnet.FrameInQueuedSession(
-            nixnet_in_interface,
+            can_in_interface,
             database_name,
             cluster_name,
             frame_name) as input_session:

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -26,6 +26,18 @@ def can_out_interface(request):
     return interface
 
 
+@pytest.fixture
+def lin_in_interface(request):
+    interface = request.config.getoption("--lin-in-interface")
+    return interface
+
+
+@pytest.fixture
+def lin_out_interface(request):
+    interface = request.config.getoption("--lin-out-interface")
+    return interface
+
+
 def raise_code(code):
     raise errors.XnetError("", code)
 
@@ -96,6 +108,20 @@ def test_session_properties(can_out_interface):
         print(output_session.queue_size)
         output_session.queue_size = 2040
         assert output_session.queue_size == 2040
+
+
+@pytest.mark.integration
+def test_session_lin_properties(lin_in_interface):
+    """Verify Session properties.
+
+    Ideally, mutable properties would be set to multiple values and we'd test
+    for the intended side-effect.  That'll be a massive undertaking.  For now,
+    ensure they are settable and getttable.
+    """
+    database_name = 'NIXNET_exampleLDF'
+
+    with nixnet.FrameInStreamSession(lin_in_interface, database_name) as input_session:
+        print(input_session.lin_comm)
 
 
 @pytest.mark.integration

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -160,10 +160,10 @@ def test_parse_lin_comm_bitfield():
     assert comm == types.LinComm(
         sleep=False,
         state=constants.LinCommState.IDLE,
-        last_err=constants.LinLastErrCode.NONE,
-        last_err_received=0,
-        last_err_expected=0,
-        last_err_id=0,
+        last_err=constants.LinLastErr.NONE,
+        err_received=0,
+        err_expected=0,
+        err_id=0,
         tcvr_rdy=False,
         sched_index=0)
 
@@ -171,10 +171,10 @@ def test_parse_lin_comm_bitfield():
     assert comm == types.LinComm(
         sleep=True,
         state=constants.LinCommState.INACTIVE,
-        last_err=constants.LinLastErrCode.CRC,
-        last_err_received=255,
-        last_err_expected=255,
-        last_err_id=63,
+        last_err=constants.LinLastErr.CRC,
+        err_received=255,
+        err_expected=255,
+        err_id=63,
         tcvr_rdy=False,
         sched_index=255)
 

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -154,6 +154,31 @@ def test_parse_can_comm_bitfield():
         rx_err_count=255)
 
 
+def test_parse_lin_comm_bitfield():
+    """A part of Session.lin_comm"""
+    comm = _utils.parse_lin_comm_bitfield(0, 0)
+    assert comm == types.LinComm(
+        sleep=False,
+        state=constants.LinCommState.IDLE,
+        last_err=constants.LinLastErrCode.NONE,
+        last_err_received=0,
+        last_err_expected=0,
+        last_err_id=0,
+        tcvr_rdy=False,
+        sched_index=0)
+
+    comm = _utils.parse_lin_comm_bitfield(0xFFFFFF6B, 0xFFFFFFFF)
+    assert comm == types.LinComm(
+        sleep=True,
+        state=constants.LinCommState.INACTIVE,
+        last_err=constants.LinLastErrCode.CRC,
+        last_err_received=255,
+        last_err_expected=255,
+        last_err_id=63,
+        tcvr_rdy=False,
+        sched_index=255)
+
+
 def assert_can_frame(index, sent, received):
     assert sent.identifier == received.identifier
     assert sent.echo == received.echo

--- a/tests/test_session_intf.py
+++ b/tests/test_session_intf.py
@@ -11,45 +11,45 @@ from nixnet import errors
 
 
 @pytest.fixture
-def nixnet_in_interface(request):
+def can_in_interface(request):
     interface = request.config.getoption("--can-in-interface")
     return interface
 
 
 @pytest.fixture
-def nixnet_out_interface(request):
+def can_out_interface(request):
     interface = request.config.getoption("--can-out-interface")
     return interface
 
 
 @pytest.mark.integration
-def test_intf_container(nixnet_in_interface):
+def test_intf_container(can_in_interface):
     database_name = 'NIXNET_example'
     cluster_name = 'CAN_Cluster'
     frame_name = 'CANEventFrame1'
 
     with nixnet.FrameInQueuedSession(
-            nixnet_in_interface,
+            can_in_interface,
             database_name,
             cluster_name,
             frame_name) as input_session:
         assert input_session.intf == input_session.intf
-        assert input_session.intf == nixnet_in_interface
+        assert input_session.intf == can_in_interface
         assert not (input_session.intf == "<random>")
         assert not (input_session.intf == 5)
 
         assert not (input_session.intf != input_session.intf)
-        assert not (input_session.intf != nixnet_in_interface)
+        assert not (input_session.intf != can_in_interface)
         assert input_session.intf != "<random>"
         assert input_session.intf != 5
 
-        assert str(input_session.intf) == nixnet_in_interface
+        assert str(input_session.intf) == can_in_interface
 
         print(repr(input_session.intf))
 
 
 @pytest.mark.integration
-def test_intf_properties_settable_only_when_stopped(nixnet_out_interface):
+def test_intf_properties_settable_only_when_stopped(can_out_interface):
     """Verify Interface properties settable only when stopped.
 
     Ensure that Interface properties are only allowed to be set when the session is stopped.
@@ -59,7 +59,7 @@ def test_intf_properties_settable_only_when_stopped(nixnet_out_interface):
     frame_name = 'CANEventFrame1'
 
     with nixnet.FrameOutQueuedSession(
-            nixnet_out_interface,
+            can_out_interface,
             database_name,
             cluster_name,
             frame_name) as output_session:
@@ -94,12 +94,12 @@ def test_intf_properties_settable_only_when_stopped(nixnet_out_interface):
 
 
 @pytest.mark.integration
-def test_stream_session_requires_baud_rate(nixnet_out_interface):
+def test_stream_session_requires_baud_rate(can_out_interface):
     """Stream session requires setting baud rate.
 
     Ensure Stream session cannot start without setting the baud_rate property.
     """
-    with nixnet.FrameOutStreamSession(nixnet_out_interface) as output_session:
+    with nixnet.FrameOutStreamSession(can_out_interface) as output_session:
         with pytest.raises(errors.XnetError) as start_excinfo:
             output_session.start()
         assert start_excinfo.value.error_type == constants.Err.BAUD_RATE_NOT_CONFIGURED
@@ -112,13 +112,13 @@ def test_stream_session_requires_baud_rate(nixnet_out_interface):
 
 
 @pytest.mark.integration
-def test_sleep_transition(nixnet_in_interface):
+def test_sleep_transition(can_in_interface):
     database_name = 'NIXNET_example'
     cluster_name = 'CAN_Cluster'
     frame_name = 'CANEventFrame1'
 
     with nixnet.FrameInQueuedSession(
-            nixnet_in_interface,
+            can_in_interface,
             database_name,
             cluster_name,
             frame_name) as input_session:

--- a/tests/test_signals.py
+++ b/tests/test_signals.py
@@ -10,25 +10,25 @@ import nixnet
 
 
 @pytest.fixture
-def nixnet_in_interface(request):
+def can_in_interface(request):
     interface = request.config.getoption("--can-in-interface")
     return interface
 
 
 @pytest.fixture
-def nixnet_out_interface(request):
+def can_out_interface(request):
     interface = request.config.getoption("--can-out-interface")
     return interface
 
 
 @pytest.mark.integration
-def test_signals_container(nixnet_in_interface):
+def test_signals_container(can_in_interface):
     database_name = 'NIXNET_example'
     cluster_name = 'CAN_Cluster'
     signal_name = 'CANEventSignal1'
 
     with nixnet.SignalInSinglePointSession(
-            nixnet_in_interface,
+            can_in_interface,
             database_name,
             cluster_name,
             signal_name) as input_session:
@@ -57,18 +57,18 @@ def test_signals_container(nixnet_in_interface):
 
 
 @pytest.mark.integration
-def test_singlepoint_loopback(nixnet_in_interface, nixnet_out_interface):
+def test_singlepoint_loopback(can_in_interface, can_out_interface):
     database_name = 'NIXNET_example'
     cluster_name = 'CAN_Cluster'
     signal_names = ['CANEventSignal1', 'CANEventSignal2']
 
     with nixnet.SignalInSinglePointSession(
-            nixnet_in_interface,
+            can_in_interface,
             database_name,
             cluster_name,
             signal_names) as input_session:
         with nixnet.SignalOutSinglePointSession(
-                nixnet_out_interface,
+                can_out_interface,
                 database_name,
                 cluster_name,
                 signal_names) as output_session:

--- a/tests/test_system.py
+++ b/tests/test_system.py
@@ -13,13 +13,13 @@ from nixnet import system
 
 
 @pytest.fixture
-def nixnet_in_interface(request):
+def can_in_interface(request):
     interface = request.config.getoption("--can-in-interface")
     return interface
 
 
 @pytest.fixture
-def nixnet_out_interface(request):
+def can_out_interface(request):
     interface = request.config.getoption("--can-out-interface")
     return interface
 
@@ -57,7 +57,7 @@ def test_system_properties():
 
 
 @pytest.mark.integration
-def test_system_intf_refs_superset(nixnet_in_interface, nixnet_out_interface):
+def test_system_intf_refs_superset(can_in_interface, can_out_interface):
     with system.System() as sys:
         intfs = set(sys.intf_refs_all)
         can_intfs = set(sys.intf_refs_can)
@@ -67,7 +67,7 @@ def test_system_intf_refs_superset(nixnet_in_interface, nixnet_out_interface):
 
 
 @pytest.mark.integration
-def test_system_intf_refs_all_superset(nixnet_in_interface, nixnet_out_interface):
+def test_system_intf_refs_all_superset(can_in_interface, can_out_interface):
     with system.System() as sys:
         intfs_all = set(sys.intf_refs_all)
         intfs = set(sys.intf_refs)
@@ -95,7 +95,7 @@ def test_device_container():
 
 
 @pytest.mark.integration
-def test_device_properties(nixnet_in_interface):
+def test_device_properties(can_in_interface):
     """Verify Device properties.
 
     Ideally we'd match these against a known piece of hardware to ensure the
@@ -103,13 +103,13 @@ def test_device_properties(nixnet_in_interface):
     to run these tests with any piece of hardware for most properties.  For
     now, we'll just verify the calls don't call catastrophically and someone
     can always run py.test with ``-s``_.  For ``int_refs_all``, we can at least
-    make sure that one device reports ``nixnet_in_interface``_.
+    make sure that one device reports ``can_in_interface``_.
     """
     with system.System() as sys:
         devs = list(sys.dev_refs)
         assert 0 < len(devs), "Pre-requisite failed"
         for dev in devs:
-            in_intfs = [intf for intf in dev.intf_refs_all if intf == nixnet_in_interface]
+            in_intfs = [intf for intf in dev.intf_refs_all if intf == can_in_interface]
             if len(in_intfs) == 1:
                 break
         else:
@@ -128,20 +128,20 @@ def test_device_properties(nixnet_in_interface):
 
 
 @pytest.mark.integration
-def test_intf_container(nixnet_in_interface):
+def test_intf_container(can_in_interface):
     with system.System() as sys:
         intfs = list(sys.intf_refs_all)
-        in_intfs = [intf for intf in intfs if intf == nixnet_in_interface]
+        in_intfs = [intf for intf in intfs if intf == can_in_interface]
         assert len(in_intfs) == 1
         in_intf = in_intfs[0]
 
-        assert str(in_intf) == nixnet_in_interface
+        assert str(in_intf) == can_in_interface
 
-        assert in_intf == nixnet_in_interface
+        assert in_intf == can_in_interface
         assert in_intf == in_intf
         assert not (in_intf == 100)
 
-        assert not (in_intf != nixnet_in_interface)
+        assert not (in_intf != can_in_interface)
         assert not (in_intf != in_intf)
         assert in_intf != "<Invalid>"
         assert in_intf != 100
@@ -152,7 +152,7 @@ def test_intf_container(nixnet_in_interface):
 
 
 @pytest.mark.integration
-def test_intf_blink(nixnet_in_interface):
+def test_intf_blink(can_in_interface):
     """Verify LEDs can be blinked.
 
     Since we don't have a camera watching the LEDs, we can at least test if we
@@ -166,7 +166,7 @@ def test_intf_blink(nixnet_in_interface):
     """
     with system.System() as sys:
         intfs = list(sys.intf_refs_all)
-        in_intfs = [intf for intf in intfs if intf == nixnet_in_interface]
+        in_intfs = [intf for intf in intfs if intf == can_in_interface]
         assert len(in_intfs) == 1, "Pre-requisite failed"
         in_intf = in_intfs[0]
 
@@ -175,7 +175,7 @@ def test_intf_blink(nixnet_in_interface):
         time.sleep(0.01)
         in_intf.blink(constants.BlinkMode.DISABLE)
         time.sleep(0.01)
-        with nixnet.FrameInStreamSession(nixnet_in_interface) as input_session:
+        with nixnet.FrameInStreamSession(can_in_interface) as input_session:
             input_session.intf.baud_rate = 125000
             input_session.start()
             with pytest.raises(errors.XnetError) as excinfo:
@@ -187,7 +187,7 @@ def test_intf_blink(nixnet_in_interface):
 
 
 @pytest.mark.integration
-def test_intf_properties(nixnet_in_interface):
+def test_intf_properties(can_in_interface):
     """Verify Interface properties.
 
     Ideally we'd match these against a known piece of hardware to ensure the
@@ -198,7 +198,7 @@ def test_intf_properties(nixnet_in_interface):
     """
     with system.System() as sys:
         intfs = list(sys.intf_refs_all)
-        in_intfs = [intf for intf in intfs if intf == nixnet_in_interface]
+        in_intfs = [intf for intf in intfs if intf == can_in_interface]
         assert len(in_intfs) == 1, "Pre-requisite failed"
         in_intf = in_intfs[0]
 


### PR DESCRIPTION
TODO
- [x] Document `lin_no_response_to_in_strm`
- [x] Update link to actual name of `change_lin_sched`
- [x] Update link to actual `lin_comm`
- [x] Get second u32 out of [lin_comm](http://zone.ni.com/reference/en-XX/help/372841N-01/nixnet/nxreadstate/)
- [ ] Write intf property tests
- [x] Write session.lin_comm tests

See #91 

BREAKING CHANGE:

Some functions/properties/parameter names have changed.  Technically we
didn't support these before but someone might have started to use them
anyways.

- session.intf.set_lin_sleep(value) -> session.intf.set_lin_sleep(state)
- session.intf.lin_diag_p_2min -> session.intf.lin_diag_p2min
- session.intf.lin_diag_s_tmin -> lin_diag_stmin
- session.intf.lino_str_slv_rsp_lst_by_nad -> session.intf.lin_ostr_slv_rsp_lst_by_nad

Checklist

- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nixnet-python/blob/master/CONTRIBUTING.rst).
- [x] New tests have been created for any new features or regression tests for bugfixes.
- [x] `tox` successfully runs, including unit tests and style checks (see [CONTRIBUTING.md](https://github.com/ni/nixnet-python/blob/master/CONTRIBUTING.rst)).