### PR TITLE
docs(API): Document `System`

### DIFF
--- a/docs/api_reference.rst
+++ b/docs/api_reference.rst
@@ -11,6 +11,7 @@ API Reference
    api_reference/session
    api_reference/system
    api_reference/convert
+   api_reference/system
    api_reference/constants
    api_reference/types
    api_reference/errors

--- a/docs/api_reference/system.rst
+++ b/docs/api_reference/system.rst
@@ -7,3 +7,5 @@ nixnet.system
 
    system/system
    system/databases
+   system/device
+   system/interface

--- a/docs/api_reference/system/device.rst
+++ b/docs/api_reference/system/device.rst
@@ -1,0 +1,6 @@
+nixnet.system.device
+====================
+
+.. automodule:: nixnet.system._device
+    :members:
+    :show-inheritance:

--- a/docs/api_reference/system/interface.rst
+++ b/docs/api_reference/system/interface.rst
@@ -1,0 +1,6 @@
+nixnet.system.interface
+=======================
+
+.. automodule:: nixnet.system._interface
+    :members:
+    :show-inheritance:

--- a/docs/api_reference/system/system.rst
+++ b/docs/api_reference/system/system.rst
@@ -3,5 +3,3 @@ nixnet.system.system
 
 .. automodule:: nixnet.system.system
     :members:
-    :show-inheritance:
-    :inherited-members:

--- a/nixnet/_enums.py
+++ b/nixnet/_enums.py
@@ -1214,6 +1214,17 @@ class StartStopScope(enum.Enum):
 
 
 class BlinkMode(enum.Enum):
+    '''Interface blink mode.
+
+    Values:
+        DISABLE:
+            Disable blinking for identification.  This option turns off both
+            LEDs for the port.
+        ENABLE:
+            Enable blinking for identification.  Both LEDs of the interface's
+            physical port turn on and off.  The hardware blinks the LEDs
+            automatically until you disable.
+    '''
     DISABLE = _cconsts.NX_BLINK_DISABLE
     ENABLE = _cconsts.NX_BLINK_ENABLE
 
@@ -1549,16 +1560,46 @@ class Merge(enum.Enum):
 
 
 class DongleState(enum.Enum):
+    '''Dongle State.
+
+    Values:
+        NO_DONGLE_NO_EXT_POWER:
+            No dongle, no external power.
+        NO_DONGLE_EXT_POWER:
+            No dongle, has external power.
+        DONGLE_NO_EXT_POWER:
+            Has dongle, no external power.
+        READY:
+            Ready.
+        BUSY:
+            Busy.
+        COMM_ERROR:
+            Comm Error.
+        OVERCURRENT:
+            Overcurrent.
+    '''
     NO_DONGLE_NO_EXT_POWER = _cconsts.NX_DONGLE_STATE_NO_DONGLE_NO_EXT_POWER
     NO_DONGLE_EXT_POWER = _cconsts.NX_DONGLE_STATE_NO_DONGLE_EXT_POWER
     DONGLE_NO_EXT_POWER = _cconsts.NX_DONGLE_STATE_DONGLE_NO_EXT_POWER
     READY = _cconsts.NX_DONGLE_STATE_READY
     BUSY = _cconsts.NX_DONGLE_STATE_BUSY
     COMM_ERROR = _cconsts.NX_DONGLE_STATE_COMM_ERROR
-    OVER_CURRENT = _cconsts.NX_DONGLE_STATE_OVER_CURRENT
+    OVERCURRENT = _cconsts.NX_DONGLE_STATE_OVER_CURRENT
 
 
 class DongleId(enum.Enum):
+    '''Dongle ID
+
+    Values:
+        HSCAN:
+            CAN High Speed
+        XSCAN:
+            CAN Software-Selectable
+        LIN:
+            LIN
+        DONGLE_LESS:
+            Dongle-Less Design
+    '''
     LSCAN = _cconsts.NX_DONGLE_ID_LS_CAN
     HSCAN = _cconsts.NX_DONGLE_ID_HS_CAN
     SWCAN = _cconsts.NX_DONGLE_ID_SW_CAN
@@ -1576,6 +1617,7 @@ class Phase(enum.Enum):
 
 
 class DevForm(enum.Enum):
+    '''Device physical form factor.'''
     PXI = _cconsts.NX_DEV_FORM_PXI
     PCI = _cconsts.NX_DEV_FORM_PCI
     C_SERIES = _cconsts.NX_DEV_FORM_C_SERIES
@@ -1584,6 +1626,12 @@ class DevForm(enum.Enum):
 
 
 class CanTermCap(enum.Enum):
+    '''CAN Termination Capability.
+
+    Values:
+        NO
+        YES
+    '''
     NO = _cconsts.NX_CAN_TERM_CAP_NO
     YES = _cconsts.NX_CAN_TERM_CAP_YES
 
@@ -1634,6 +1682,18 @@ class CanTerm(enum.Enum):
 
 
 class CanTcvrCap(enum.Enum):
+    '''CAN bus phusical transceivers support.
+
+    Values:
+        HS:
+            High-Speed / Flexible Data-Rate (HS/FD).
+        LS:
+            Low-Speed / Fault-Tolerant (LS//FT)
+        XS:
+            XS (HS//FD, LS/FT, SW, or External)
+        XSHSLS:
+            XS (HS//FD, LS/FT)
+    '''
     HS = _cconsts.NX_CAN_TCVR_CAP_HS
     LS = _cconsts.NX_CAN_TCVR_CAP_LS
     XS = _cconsts.NX_CAN_TCVR_CAP_XS

--- a/nixnet/_enums.py
+++ b/nixnet/_enums.py
@@ -1610,6 +1610,11 @@ class DongleId(enum.Enum):
 
 
 class Phase(enum.Enum):
+    '''Version Phase.
+
+    Values:
+        RELEASE
+    '''
     DEVELOPMENT = _cconsts.NX_PHASE_DEVELOPMENT
     ALPHA = _cconsts.NX_PHASE_ALPHA
     BETA = _cconsts.NX_PHASE_BETA

--- a/nixnet/system/_device.py
+++ b/nixnet/system/_device.py
@@ -4,8 +4,6 @@ from __future__ import print_function
 
 import typing  # NOQA: F401
 
-import six
-
 from nixnet import _props
 from nixnet import constants
 
@@ -13,6 +11,7 @@ from nixnet.system import _interface
 
 
 class Device(object):
+    '''Physical XNET devices in the system.'''
 
     def __init__(self, handle):
         # type: (int) -> None
@@ -21,8 +20,6 @@ class Device(object):
     def __eq__(self, other):
         if isinstance(other, self.__class__):
             return self._handle == typing.cast(Device, other._handle)
-        elif isinstance(other, six.string_types):
-            return self._name == typing.cast(typing.Text, other)
         else:
             return NotImplemented
 
@@ -36,10 +33,6 @@ class Device(object):
     def __hash__(self):
         return hash(self._handle)
 
-    def __str__(self):
-        # type: () -> typing.Text
-        return self._name
-
     def __repr__(self):
         # type: () -> typing.Text
         return 'Device(handle={0})'.format(self._handle)
@@ -47,46 +40,61 @@ class Device(object):
     @property
     def form_fac(self):
         # type: () -> constants.DevForm
+        ''':any:`nixnet._enums.DevForm`: XNET board form factor.'''
         return constants.DevForm(_props.get_device_form_fac(self._handle))
 
     @property
     def intf_refs(self):
         # type: () -> typing.Iterable[_interface.Interface]
+        '''iter of :any:`nixnet.system._interface.Interface`: Interfaces associated with this device.'''
         for ref in _props.get_device_intf_refs(self._handle):
+            yield _interface.Interface(ref)
+
+    @property
+    def intf_refs_all(self):
+        # type: () -> typing.Iterable[_interface.Interface]
+        '''iter of :any:`nixnet.system._interface.Interface`: Interfaces associated with this device.
+
+        This Includes those not equipped with a Transceiver Cable.
+        '''
+        for ref in _props.get_device_intf_refs_all(self._handle):
             yield _interface.Interface(ref)
 
     @property
     def num_ports(self):
         # type: () -> int
+        '''int: The number of physical port connectors on the XNET board.'''
         return _props.get_device_num_ports(self._handle)
+
+    @property
+    def num_ports_all(self):
+        # type: () -> int
+        '''int: The number of physical port connectors on the XNET board.
+
+        This Includes those not equipped with a Transceiver Cable.
+        '''
+        return _props.get_device_num_ports_all(self._handle)
 
     @property
     def product_num(self):
         # type: () -> int
+        '''int: The numeric portion of the XNET device product name.'''
         return _props.get_device_product_num(self._handle)
+
+    @property
+    def product_name(self):
+        # type: () -> typing.Text
+        '''str: The XNET device product name.'''
+        return _props.get_device_name(self._handle)
 
     @property
     def ser_num(self):
         # type: () -> int
+        '''int: Serial number associated with the XNET device.'''
         return _props.get_device_ser_num(self._handle)
 
     @property
     def slot_num(self):
         # type: () -> int
+        '''int: Physical slot where the module is located within a chassis.'''
         return _props.get_device_slot_num(self._handle)
-
-    @property
-    def num_ports_all(self):
-        # type: () -> int
-        return _props.get_device_num_ports_all(self._handle)
-
-    @property
-    def intf_refs_all(self):
-        # type: () -> typing.Iterable[_interface.Interface]
-        for ref in _props.get_device_intf_refs_all(self._handle):
-            yield _interface.Interface(ref)
-
-    @property
-    def _name(self):
-        # type: () -> typing.Text
-        return _props.get_device_name(self._handle)

--- a/nixnet/system/_interface.py
+++ b/nixnet/system/_interface.py
@@ -12,6 +12,7 @@ from nixnet import constants
 
 
 class Interface(object):
+    '''Interfaces associated with a physical hardware device.'''
 
     def __init__(self, handle):
         # type: (int) -> None
@@ -48,60 +49,159 @@ class Interface(object):
     @property
     def num(self):
         # type: () -> int
+        '''int: The unique number associated with the XNET interface.
+
+        The XNET driver assigns each port connector in the system a unique
+        number XNET driver. This number, plus its protocol name, is the
+        interface name.
+        '''
         return _props.get_interface_num(self._handle)
 
     @property
     def port_num(self):
         # type: () -> int
+        '''int: Physical port number printed near the connector on the XNET device.
+
+        The port numbers on an XNET board are physically identified with
+        numbering. Use this property, along with the XNET Device Serial Number
+        property, to associate an XNET interface with a physical (XNET board
+        and port) combination.
+        '''
         return _props.get_interface_port_num(self._handle)
 
     @property
     def protocol(self):
         # type: () -> constants.Protocol
+        ''':any:`nixnet._enums.Protocol`: Protocol supported by the interface.'''
         return constants.Protocol(_props.get_interface_protocol(self._handle))
 
     @property
     def can_term_cap(self):
         # type: () -> constants.CanTermCap
+        ''':any:`nixnet._enums.CanTermCap`: Indicates whether the XNET interface can terminate the CAN bus.
+
+        Signal reflections on the CAN bus can cause communication failure. To
+        prevent reflections, termination can be present as external resistance
+        or resistance the XNET board applies internally. This property
+        determines whether the XNET board can add termination to the bus.
+        '''
         return constants.CanTermCap(_props.get_interface_can_term_cap(self._handle))
 
     @property
     def can_tcvr_cap(self):
         # type: () -> constants.CanTcvrCap
+        ''':any:`nixnet._enums.CanTcvrCap`: Indicates the CAN bus physical transceiver support.'''
         return constants.CanTcvrCap(_props.get_interface_can_tcvr_cap(self._handle))
 
     @property
     def dongle_state(self):
         # type: () -> constants.DongleState
+        ''':any:`nixnet._enums.DongleState`: Indicates the connected Transceiver Cable's state.
+
+        Some Transceiver Cable types require external power from the network
+        connector for operation. Refer to the hardware-specific manual for more
+        information.
+        '''
         return constants.DongleState(_props.get_interface_dongle_state(self._handle))
 
     @property
     def dongle_id(self):
         # type: () -> constants.DongleId
+        ''':any:`nixnet._enums.DongleId`: Indicates the connected Transceiver Cable's type.
+
+        Dongle-Less Design indicates this interface is not a Transceiver Cable
+        but a regular XNET expansion card, cDAQ Module, and so on.
+        '''
         return constants.DongleId(_props.get_interface_dongle_id(self._handle))
 
     @property
     def dongle_revision(self):
         # type: () -> int
+        '''int: The connected Transceiver Cable's hardware revision number.'''
         return _props.get_interface_dongle_revision(self._handle)
 
     @property
     def dongle_firmware_version(self):
         # type: () -> int
+        '''int: The connected Transceiver Cable's firmware revision number.'''
         return _props.get_interface_dongle_firmware_version(self._handle)
 
     @property
     def dongle_compatible_revision(self):
         # type: () -> int
+        '''int: The oldest driver version compatible with the connected Transceiver Cable's hardware revision.
+
+        The number is relative to the first driver version that supported the
+        particular Transceiver Cable model, starting with 1 for the original
+        revision.
+
+        .. note:: A Transceiver Cable hardware revision might require a later
+           XNET driver than the version that introduced support for this model for
+           operation.
+        '''
         return _props.get_interface_dongle_compatible_revision(self._handle)
 
     @property
     def dongle_compatible_firmware_version(self):
         # type: () -> int
+        '''int: The oldest driver version compatible with the connected Transceiver Cable's firmware.
+
+        The number is relative to the first driver version that supported the
+        Transceiver Cable, starting with 1 for the original revision.
+
+        ..note:: A Transceiver Cable running an updated firmware version may
+           require a later XNET driver than the version it shipped with for
+           operation.
+        '''
         return _props.get_interface_dongle_compatible_firmware_version(self._handle)
 
     def blink(self, modifier):
         # type: (constants.BlinkMode) -> None
+        '''Blinks LEDs for the XNET interface to identify its physical port in the system.
+
+        Each XNET device contains one or two physical ports. Each port is
+        labeled on the hardware as Port 1 or Port 2. The XNET device also
+        provides two LEDs per port. For a two-port board, LEDs 1 and 2 are
+        assigned to Port 1, and LEDs 3 and 4 are assigned to physical Port 2.
+
+        When your application uses multiple XNET devices, this function helps
+        to identify each interface to associate its software behavior to its
+        hardware connection (port). Prior to running your XNET sessions, you
+        can call this function to blink the interface LEDs.
+
+        For example, if you have a system with three PCI CAN cards, each with
+        two ports, you can use this function to blink the LEDs for interface
+        CAN4, to identify it among the six CAN ports.
+
+        The LEDs of each port support two states:
+            Identification:
+                Blink LEDs to identify the physical port assigned to the interface.
+            In Use:
+                LED behavior that XNET sessions control.
+
+        **Identification LED State**
+
+        You can use the ``blink`` function only in the Identification state. If
+        you call this function while one or more XNET sessions for the
+        interface are open (created), it returns an error, because the port's
+        LEDs are in the In Use state.
+
+        **In Use LED State**
+
+        When you create an XNET session for the interface, the LEDs for that
+        physical port transition to the In Use state. If you called the ``blink``
+        function previously to enable blinking for identification, that LED
+        behavior no longer applies. The In Use LED state remains until all XNET
+        sessions are cleared. This typically occurs when the application
+        terminates. The patterns that appear on the LEDs while In Use are
+        documented in LEDs.
+
+        Args:
+            moodifier (:any:`nixnet._enums.BlinkMode`): Controls LED blinking
+
+                Both LEDs blink green (not red). The blinking rate is approximately
+                three times per second.
+        '''
         _funcs.nx_blink(self._handle, modifier)
 
     @property

--- a/nixnet/system/system.py
+++ b/nixnet/system/system.py
@@ -78,18 +78,31 @@ class System(object):
     @property
     def dev_refs(self):
         # type: () -> typing.Iterable[_device.Device]
+        '''iter of :any:`nixnet.system._device.Device`: Physical XNET devices in the system.'''
         for ref in _props.get_system_dev_refs(self._handle):
             yield _device.Device(ref)
 
     @property
     def intf_refs(self):
         # type: () -> typing.Iterable[_interface.Interface]
+        '''iter of :any:`nixnet.system._interface.Interface`: Available interfaces on the system.'''
         for ref in _props.get_system_intf_refs(self._handle):
+            yield _interface.Interface(ref)
+
+    @property
+    def intf_refs_all(self):
+        # type: () -> typing.Iterable[_interface.Interface]
+        '''iter of :any:`nixnet.system._interface.Interface`: Available interfaces on the system.
+
+        This Includes those not equipped with a Transceiver Cable.
+        '''
+        for ref in _props.get_system_intf_refs_all(self._handle):
             yield _interface.Interface(ref)
 
     @property
     def intf_refs_can(self):
         # type: () -> typing.Iterable[_interface.Interface]
+        '''iter of :any:`nixnet.system._interface.Interface`: Available interfaces on the system (CAN Protocol).'''
         for ref in _props.get_system_intf_refs_can(self._handle):
             yield _interface.Interface(ref)
 
@@ -102,12 +115,20 @@ class System(object):
     @property
     def intf_refs_lin(self):
         # type: () -> typing.Iterable[_interface.Interface]
+        '''iter of :any:`nixnet.system._interface.Interface`: Available interfaces on the system (LIN Protocol).'''
         for ref in _props.get_system_intf_refs_lin(self._handle):
             yield _interface.Interface(ref)
 
     @property
     def ver(self):
         # type: () -> types.DriverVersion
+        ''':any:`nixnet.types.DriverVersion`: The driver version (larger numbers imply a newer version).
+
+        Use this for:
+
+        * Determining the driver functionality or release date
+        * Determining upgrade availability
+        '''
         return types.DriverVersion(
             self._ver_major,
             self._ver_minor,
@@ -139,9 +160,3 @@ class System(object):
     def _ver_update(self):
         # type: () -> int
         return _props.get_system_ver_update(self._handle)
-
-    @property
-    def intf_refs_all(self):
-        # type: () -> typing.Iterable[_interface.Interface]
-        for ref in _props.get_system_intf_refs_all(self._handle):
-            yield _interface.Interface(ref)

--- a/nixnet/types.py
+++ b/nixnet/types.py
@@ -31,9 +31,23 @@ __all__ = [
     'XnetFrame']
 
 
-DriverVersion = collections.namedtuple(
-    'DriverVersion',
+DriverVersion_ = collections.namedtuple(
+    'DriverVersion_',
     ['major', 'minor', 'update', 'phase', 'build'])
+
+
+class DriverVersion(DriverVersion_):
+    """Driver Version
+
+    The arguments align with the following fields: ``[major].[minor].[update][phase][build]``.
+
+    Attributes:
+        major (int):
+        minor (int):
+        update (int):
+        phase (:any:`nixnet._enums.Phase`):
+        build (int):
+    """
 
 
 CanComm_ = collections.namedtuple(

--- a/tests/test_system.py
+++ b/tests/test_system.py
@@ -70,12 +70,10 @@ def test_device_container():
         assert 0 < len(devs), "Pre-requisite failed"
         dev = devs[0]
 
-        assert dev == str(dev)
         assert dev == dev
         assert not (dev == 100)
 
         assert not (dev != dev)
-        assert dev != "<Invalid>"
         assert dev != 100
 
         set([dev])  # Testing `__hash__`
@@ -110,7 +108,9 @@ def test_device_properties(can_in_interface):
 
         print(dev.form_fac)
         print(dev.num_ports)
+        print(dev.product_name)
         print(dev.product_num)
+        assert str(dev.product_num) in dev.product_name
         print(dev.ser_num)
         print(dev.slot_num)
         print(dev.num_ports_all)
@@ -192,6 +192,7 @@ def test_intf_properties(can_in_interface):
         in_intf = in_intfs[0]
 
         print(in_intf.num)
+        assert str(in_intf).endswith(str(in_intf.num))
         print(in_intf.port_num)
         print(in_intf.protocol)
         print(in_intf.can_term_cap)


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nixnet-python/blob/master/CONTRIBUTING.rst).
- [x] New tests have been created for any new features or regression tests for bugfixes.
- [x] `tox` successfully runs, including unit tests and style checks (see [CONTRIBUTING.md](https://github.com/ni/nixnet-python/blob/master/CONTRIBUTING.rst)).