### PR TITLE
feat(DB): Add methods to get_dbc_attribute

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .mypy_cache/
 .tox/
 junit/
+docs/_build/
 __pycache__
 .coverage
 coverage.xml

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -5,3 +5,4 @@ recursive-include nixnet *.py
 recursive-include nixnet_examples *.py
 include nixnet_examples/databases/custom_database.dbc
 recursive-include tests *.py
+include tests/databases/attributes.dbc

--- a/docs/api_reference.rst
+++ b/docs/api_reference.rst
@@ -11,6 +11,7 @@ API Reference
    api_reference/session
    api_reference/convert
    api_reference/system
+   api_reference/database
    api_reference/constants
    api_reference/types
    api_reference/errors

--- a/docs/api_reference/database.rst
+++ b/docs/api_reference/database.rst
@@ -1,0 +1,12 @@
+nixnet.database
+===============
+
+.. toctree::
+   :maxdepth: 3
+   :caption: API Reference:
+
+   database/cluster
+   database/ecu
+   database/frame
+   database/signal
+   database/dbc_attributes

--- a/docs/api_reference/database/cluster.rst
+++ b/docs/api_reference/database/cluster.rst
@@ -1,0 +1,7 @@
+nixnet.database.cluster
+=======================
+
+.. automodule:: nixnet.database._cluster
+    :members:
+    :inherited-members:
+    :show-inheritance:

--- a/docs/api_reference/database/dbc_attributes.rst
+++ b/docs/api_reference/database/dbc_attributes.rst
@@ -1,0 +1,7 @@
+nixnet.database.dbc_attributes
+==============================
+
+.. automodule:: nixnet.database._dbc_attributes
+    :members:
+    :inherited-members:
+    :show-inheritance:

--- a/docs/api_reference/database/ecu.rst
+++ b/docs/api_reference/database/ecu.rst
@@ -1,0 +1,7 @@
+nixnet.database.ecu
+===================
+
+.. automodule:: nixnet.database._ecu
+    :members:
+    :inherited-members:
+    :show-inheritance:

--- a/docs/api_reference/database/frame.rst
+++ b/docs/api_reference/database/frame.rst
@@ -1,0 +1,7 @@
+nixnet.database.frame
+=====================
+
+.. automodule:: nixnet.database._frame
+    :members:
+    :inherited-members:
+    :show-inheritance:

--- a/docs/api_reference/database/signal.rst
+++ b/docs/api_reference/database/signal.rst
@@ -1,0 +1,7 @@
+nixnet.database.signal
+======================
+
+.. automodule:: nixnet.database._signal
+    :members:
+    :inherited-members:
+    :show-inheritance:

--- a/nixnet/_funcs.py
+++ b/nixnet/_funcs.py
@@ -565,12 +565,12 @@ def nxdb_get_property_size(
 
 def nxdb_get_dbc_attribute_size(
     db_object_ref,  # type: int
-    mode,  # type: int
+    mode,  # type: _enums.GetDbcAttributeMode
     attribute_name,  # type: typing.Text
 ):
     # type: (...) -> int
     db_object_ref_ctypes = _ctypedefs.nxDatabaseRef_t(db_object_ref)
-    mode_ctypes = _ctypedefs.u32(mode)
+    mode_ctypes = _ctypedefs.u32(mode.value)
     attribute_name_ctypes = _ctypedefs.char_p(attribute_name.encode('ascii'))
     attribute_text_size_ctypes = _ctypedefs.u32()
     result = _cfuncs.lib.nxdb_get_dbc_attribute_size(
@@ -585,17 +585,16 @@ def nxdb_get_dbc_attribute_size(
 
 def nxdb_get_dbc_attribute(
     db_object_ref,  # type: int
-    mode,  # type: int
+    mode,  # type:  _enums.GetDbcAttributeMode
     attribute_name,  # type: typing.Text
     attribute_text_size,  # type: int
-    attribute_text,  # type: typing.Text
 ):
-    # type: (...) -> int
+    # type: (...) -> typing.Tuple[typing.Text, bool]
     db_object_ref_ctypes = _ctypedefs.nxDatabaseRef_t(db_object_ref)
-    mode_ctypes = _ctypedefs.u32(mode)
+    mode_ctypes = _ctypedefs.u32(mode.value)
     attribute_name_ctypes = _ctypedefs.char_p(attribute_name.encode('ascii'))
     attribute_text_size_ctypes = _ctypedefs.u32(attribute_text_size)
-    attribute_text_ctypes = _ctypedefs.char_p(attribute_text.encode('ascii'))
+    attribute_text_ctypes = ctypes.create_string_buffer(attribute_text_size)
     is_default_ctypes = _ctypedefs.u32()
     result = _cfuncs.lib.nxdb_get_dbc_attribute(
         db_object_ref_ctypes,
@@ -606,7 +605,9 @@ def nxdb_get_dbc_attribute(
         ctypes.pointer(is_default_ctypes),
     )
     _errors.check_for_error(result.value)
-    return is_default_ctypes.value
+    attribute_text = attribute_text_ctypes.value.decode("ascii")
+    is_default = bool(is_default_ctypes.value)
+    return attribute_text, is_default
 
 
 def nxdb_merge(

--- a/nixnet/database/_cluster.py
+++ b/nixnet/database/_cluster.py
@@ -10,6 +10,7 @@ from nixnet import _props
 from nixnet import constants
 
 from nixnet.database import _collection
+from nixnet.database import _dbc_attributes
 from nixnet.database import _ecu
 from nixnet.database import _frame
 from nixnet.database import _linsched
@@ -17,9 +18,11 @@ from nixnet.database import _pdu
 
 
 class Cluster(object):
+    """Database cluster"""
 
     def __init__(self, handle):
         self._handle = handle
+        self._dbc_attributes = None
         self._ecus = _collection.DbCollection(
             self._handle, constants.ObjectClass.ECU, _cconsts.NX_PROP_CLST_ECU_REFS, _ecu.Ecu)
         self._frames = _collection.DbCollection(
@@ -80,6 +83,14 @@ class Cluster(object):
     @property
     def database_ref(self):
         return _props.get_cluster_database_ref(self._handle)
+
+    @property
+    def dbc_attributes(self):
+        # type: () -> _dbc_attributes.DbcAttributeCollection
+        """:any:`nixnet.database._dbc_attributes.DbcAttributeCollection`: Access the cluster's DBC attributes."""
+        if self._dbc_attributes is None:
+            self._dbc_attributes = _dbc_attributes.DbcAttributeCollection(self._handle)
+        return self._dbc_attributes
 
     @property
     def ecus(self):

--- a/nixnet/database/_dbc_attributes.py
+++ b/nixnet/database/_dbc_attributes.py
@@ -1,0 +1,135 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import collections
+import six
+import typing  # NOQA: F401
+
+from nixnet import _funcs
+from nixnet import constants
+
+
+class DbcAttributeCollection(collections.Mapping):
+    """Collection for accessing DBC attributes."""
+
+    def __init__(self, handle):
+        # type: (int) -> None
+        self._handle = handle
+
+        # Here, we are caching the attribute names and enums to work around a driver issue.
+        # The issue results in an empty attribute value after intermixing calls to get attribute values and enums.
+        # We can avoid this issue if we get all attribute enums first, before getting any attribute values.
+        self._cache = dict(
+            (name, self._get_enums(name))
+            for name in self._get_names()
+        )
+
+    def __repr__(self):
+        return '{}(handle={})'.format(type(self).__name__, self._handle)
+
+    def __eq__(self, other):
+        if isinstance(other, self.__class__):
+            return self._handle == typing.cast(DbcAttributeCollection, other)._handle
+        else:
+            return NotImplemented
+
+    def __ne__(self, other):
+        result = self.__eq__(other)
+        if result is NotImplemented:
+            return result
+        else:
+            return not result
+
+    def __hash__(self):
+        return hash(self._handle)
+
+    def __len__(self):
+        return len(list(self.keys()))
+
+    def __iter__(self):
+        return self.keys()
+
+    def __getitem__(self, key):
+        # type: (typing.Text) -> typing.Tuple[typing.Text, bool]
+        """Return the attribute value and whether it's the default value.
+
+            Args:
+                key(str): attribute name.
+            Returns:
+                tuple(str, bool): attribute value and whether it's the default value.
+        """
+        if isinstance(key, six.string_types):
+            return self._get_value(key)
+        else:
+            raise TypeError(key)
+
+    def keys(self):
+        """Return all attribute names in the collection.
+
+            Yields:
+                An iterator to all attribute names in the collection.
+        """
+        for name in self._cache:
+            yield name
+
+    def values(self):
+        """Return all attribute values in the collection.
+
+            Yields:
+                An iterator to all attribute values in the collection.
+        """
+        for name in self._cache:
+            yield self._get_value(name)
+
+    def items(self):
+        """Return all attribute names and values in the collection.
+
+            Yields:
+                An iterator to tuple pairs of attribute names and values in the collection.
+        """
+        for name in self._cache:
+            yield name, self._get_value(name)
+
+    def _get_names(self):
+        # type: () -> typing.List[typing.Text]
+        mode = constants.GetDbcAttributeMode.ATTRIBUTE_LIST
+        attribute_size = _funcs.nxdb_get_dbc_attribute_size(self._handle, mode, '')
+        attribute_info = _funcs.nxdb_get_dbc_attribute(self._handle, mode, '', attribute_size)
+        name_string = attribute_info[0]
+        name_list = [
+            name
+            for name in name_string.split(',')
+            if name.strip()
+        ]
+        return name_list
+
+    def _get_enums(self, name):
+        # type: (typing.Text) -> typing.List[typing.Text]
+        mode = constants.GetDbcAttributeMode.ENUMERATION_LIST
+        attribute_size = _funcs.nxdb_get_dbc_attribute_size(self._handle, mode, name)
+        attribute_info = _funcs.nxdb_get_dbc_attribute(self._handle, mode, name, attribute_size)
+        enum_string = attribute_info[0]
+        enum_list = [
+            enum
+            for enum in enum_string.split(',')
+            if enum.strip()
+        ]
+        return enum_list
+
+    def _get_value(self, name):
+        # type: (typing.Text) -> typing.Tuple[typing.Text, bool]
+        if name not in self._cache:
+            raise KeyError('Attribute name %s not found in DBC attributes' % name)
+
+        mode = constants.GetDbcAttributeMode.ATTRIBUTE
+        attribute_size = _funcs.nxdb_get_dbc_attribute_size(self._handle, mode, name)
+        attribute_info = _funcs.nxdb_get_dbc_attribute(self._handle, mode, name, attribute_size)
+        enums = self._cache[name]
+        if not enums:
+            return attribute_info
+
+        # This attribute is an enum. Replace the enum index with the enum string.
+        index = int(attribute_info[0])
+        attribute_info = (enums[index], attribute_info[1])
+        return attribute_info

--- a/nixnet/database/_ecu.py
+++ b/nixnet/database/_ecu.py
@@ -2,14 +2,19 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+import typing  # NOQA: F401
+
 from nixnet import _props
 from nixnet import constants
+from nixnet.database import _dbc_attributes
 
 
 class Ecu(object):
+    """Database ECU"""
 
     def __init__(self, handle):
         self._handle = handle
+        self._dbc_attributes = None
 
     def __eq__(self, other):
         if isinstance(other, self.__class__):
@@ -45,6 +50,14 @@ class Ecu(object):
     @property
     def config_status(self):
         return _props.get_ecu_config_status(self._handle)
+
+    @property
+    def dbc_attributes(self):
+        # type: () -> _dbc_attributes.DbcAttributeCollection
+        """:any:`nixnet.database._dbc_attributes.DbcAttributeCollection`: Access the ECU's DBC attributes."""
+        if self._dbc_attributes is None:
+            self._dbc_attributes = _dbc_attributes.DbcAttributeCollection(self._handle)
+        return self._dbc_attributes
 
     @property
     def name(self):

--- a/nixnet/database/_frame.py
+++ b/nixnet/database/_frame.py
@@ -10,14 +10,17 @@ from nixnet import _props
 from nixnet import constants
 
 from nixnet.database import _collection
+from nixnet.database import _dbc_attributes
 from nixnet.database import _signal
 from nixnet.database import _subframe
 
 
 class Frame(object):
+    """Database frame"""
 
     def __init__(self, handle):
         self._handle = handle
+        self._dbc_attributes = None
         self._mux_static_signals = _collection.DbCollection(
             self._handle, constants.ObjectClass.SIGNAL, _cconsts.NX_PROP_FRM_MUX_STATIC_SIG_REFS, _signal.Signal)
         self._mux_subframes = _collection.DbCollection(
@@ -73,6 +76,14 @@ class Frame(object):
     @default_payload.setter
     def default_payload(self, value):
         _props.set_frame_default_payload(self._handle, value)
+
+    @property
+    def dbc_attributes(self):
+        # type: () -> _dbc_attributes.DbcAttributeCollection
+        """:any:`nixnet.database._dbc_attributes.DbcAttributeCollection`: Access the frame's DBC attributes."""
+        if self._dbc_attributes is None:
+            self._dbc_attributes = _dbc_attributes.DbcAttributeCollection(self._handle)
+        return self._dbc_attributes
 
     @property
     def id(self):

--- a/nixnet/database/_signal.py
+++ b/nixnet/database/_signal.py
@@ -2,14 +2,19 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+import typing  # NOQA: F401
+
 from nixnet import _props
 from nixnet import constants
+from nixnet.database import _dbc_attributes
 
 
 class Signal(object):
+    """Database signal"""
 
     def __init__(self, handle):
         self._handle = handle
+        self._dbc_attributes = None
 
     def __eq__(self, other):
         if isinstance(other, self.__class__):
@@ -57,6 +62,14 @@ class Signal(object):
     @data_type.setter
     def data_type(self, value):
         _props.set_signal_data_type(self._handle, value.value)
+
+    @property
+    def dbc_attributes(self):
+        # type: () -> _dbc_attributes.DbcAttributeCollection
+        """:any:`nixnet.database._dbc_attributes.DbcAttributeCollection`: Access the signal's DBC attributes."""
+        if self._dbc_attributes is None:
+            self._dbc_attributes = _dbc_attributes.DbcAttributeCollection(self._handle)
+        return self._dbc_attributes
 
     @property
     def default(self):

--- a/tests/databases/attributes.dbc
+++ b/tests/databases/attributes.dbc
@@ -1,0 +1,86 @@
+VERSION ""
+
+
+NS_ : 
+	NS_DESC_
+	CM_
+	BA_DEF_
+	BA_
+	VAL_
+	CAT_DEF_
+	CAT_
+	FILTER
+	BA_DEF_DEF_
+	EV_DATA_
+	ENVVAR_DATA_
+	SGTYPE_
+	SGTYPE_VAL_
+	BA_DEF_SGTYPE_
+	BA_SGTYPE_
+	SIG_TYPE_REF_
+	VAL_TABLE_
+	SIG_GROUP_
+	SIG_VALTYPE_
+	SIGTYPE_VALTYPE_
+	BO_TX_BU_
+	BA_DEF_REL_
+	BA_REL_
+	BA_DEF_DEF_REL_
+	BU_SG_REL_
+	BU_EV_REL_
+	BU_BO_REL_
+	SG_MUL_VAL_
+
+BS_:
+
+BU_: ECU2 ECU1
+
+
+BO_ 1 Msg2: 8 Vector__XXX
+ SG_ StatSig : 16|8@1- (1,0) [0|0] "" Vector__XXX
+ SG_ ModDepSig m0 : 8|8@1- (1,0) [0|0] "" Vector__XXX
+ SG_ MuxSig M : 0|8@1- (1,0) [0|0] "" Vector__XXX
+
+BO_ 0 Msg1: 8 Vector__XXX
+ SG_ Sig2 : 8|8@1- (1,0) [0|0] "" Vector__XXX
+ SG_ Sig1 : 0|8@1- (1,0) [0|0] "" Vector__XXX
+
+
+
+EV_ ev1: 0 [0|0] "" 0 1 DUMMY_NODE_VECTOR0 Vector__XXX;
+
+BA_DEF_ BO_  "MsgAttr4" ENUM  "1","2","3";
+BA_DEF_ BO_  "MsgAttr3" STRING ;
+BA_DEF_ BO_  "MsgAttr2" FLOAT 0 0;
+BA_DEF_ EV_  "EnvironmentalVariable1Float" FLOAT 0 0;
+BA_DEF_ BU_  "EcuAttr1" STRING ;
+BA_DEF_  "NetworkAttr1" STRING ;
+BA_DEF_ SG_  "SigAttr1" INT 0 0;
+BA_DEF_ BO_  "MsgAttr1" INT 0 0;
+BA_DEF_  "BusType" STRING ;
+BA_DEF_REL_ BU_EV_REL_  "ControlUnitEnvVariable" INT 0 0;
+BA_DEF_REL_ BU_SG_REL_  "RxSignalAttribute" INT 0 0;
+BA_DEF_REL_ BU_BO_REL_  "TxMessageAttribute" INT 0 0;
+BA_DEF_REL_ BU_SG_REL_  "NodeRxSignal" INT 0 0;
+BA_DEF_REL_ BU_BO_REL_  "NodeTxMessage" INT 0 0;
+BA_DEF_DEF_  "MsgAttr4" "2";
+BA_DEF_DEF_  "MsgAttr3" "DefaultMsgAttr3String";
+BA_DEF_DEF_  "MsgAttr2" -11.1;
+BA_DEF_DEF_  "EnvironmentalVariable1Float" 0;
+BA_DEF_DEF_  "EcuAttr1" "xEcu1";
+BA_DEF_DEF_  "NetworkAttr1" "abc";
+BA_DEF_DEF_  "SigAttr1" 1;
+BA_DEF_DEF_  "MsgAttr1" 2;
+BA_DEF_DEF_  "BusType" "CAN";
+BA_DEF_DEF_REL_ "ControlUnitEnvVariable" 0;
+BA_DEF_DEF_REL_ "RxSignalAttribute" 0;
+BA_DEF_DEF_REL_ "TxMessageAttribute" 0;
+BA_DEF_DEF_REL_ "NodeRxSignal" 0;
+BA_DEF_DEF_REL_ "NodeTxMessage" 0;
+BA_ "EcuAttr1" BU_ ECU2 "xEcu2-Set";
+BA_ "MsgAttr4" BO_ 1 0;
+BA_ "MsgAttr3" BO_ 1 "MsgAttr3String";
+BA_ "MsgAttr2" BO_ 1 -23.33;
+BA_ "MsgAttr1" BO_ 1 22;
+BA_ "SigAttr1" SG_ 0 Sig2 11;
+

--- a/tests/test_dbc_attributes.py
+++ b/tests/test_dbc_attributes.py
@@ -1,0 +1,164 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import mock  # type: ignore
+import os
+import pytest  # type: ignore
+
+from nixnet import _cfuncs
+from nixnet import _ctypedefs
+from nixnet import database
+from nixnet.database import _dbc_attributes
+
+MockXnetLibrary = mock.create_autospec(_cfuncs.XnetLibrary, spec_set=True, instance=True)
+MockXnetLibrary.nxdb_open_database.return_value = _ctypedefs.u32(0)
+MockXnetLibrary.nxdb_close_database.return_value = _ctypedefs.u32(0)
+MockXnetLibrary.nxdb_find_object.return_value = _ctypedefs.u32(0)
+MockXnetLibrary.nxdb_get_dbc_attribute_size.return_value = _ctypedefs.u32(0)
+MockXnetLibrary.nxdb_get_dbc_attribute.return_value = _ctypedefs.u32(0)
+
+
+@mock.patch('nixnet._cfuncs.lib', MockXnetLibrary)
+def test_dbc_attributes():
+    dbc_attributes120 = _dbc_attributes.DbcAttributeCollection(120)
+    dbc_attributes130_1 = _dbc_attributes.DbcAttributeCollection(130)
+    dbc_attributes130_2 = _dbc_attributes.DbcAttributeCollection(130)
+
+    # test dunders
+    assert str(dbc_attributes120) == 'DbcAttributeCollection(handle=120)'
+    assert dbc_attributes130_1 == dbc_attributes130_2
+    assert dbc_attributes130_1 != dbc_attributes120
+    assert len({dbc_attributes120, dbc_attributes130_1, dbc_attributes130_2}) == 2  # testing `__hash__`
+    assert len(dbc_attributes120) == 0
+    for key in dbc_attributes120:
+        print(dbc_attributes120[key])
+    with pytest.raises(KeyError):
+        print(dbc_attributes120[''])
+    with pytest.raises(TypeError):
+        print(dbc_attributes120[5])
+
+    # test container
+    assert sorted(dbc_attributes120.keys()) == []
+    assert sorted(dbc_attributes120.values()) == []
+    assert sorted(dbc_attributes120.items()) == []
+
+
+@pytest.mark.integration
+def test_cluster_dbc_attributes():
+    database_filepath = os.path.join(os.path.dirname(__file__), 'databases\\attributes.dbc')
+    with database.Database(database_filepath) as db:
+        cluster = db.clusters['Cluster']
+        frame1 = cluster.frames['Msg1']
+
+        # test dunders
+        assert len(cluster.dbc_attributes) == 2
+        assert len({cluster.dbc_attributes, cluster.dbc_attributes}) == 1  # testing `__hash__`
+        assert len({cluster.dbc_attributes, frame1.dbc_attributes}) == 2  # testing `__hash__`
+        assert cluster.dbc_attributes == cluster.dbc_attributes
+        assert cluster.dbc_attributes != frame1.dbc_attributes
+        for key in cluster.dbc_attributes:
+            print(cluster.dbc_attributes[key])
+
+        # test containers
+        assert sorted(cluster.dbc_attributes.keys()) == ['BusType', 'NetworkAttr1']
+        assert sorted(cluster.dbc_attributes.values()) == [('CAN', True), ('abc', True)]
+        assert sorted(cluster.dbc_attributes.items()) == [('BusType', ('CAN', True)), ('NetworkAttr1', ('abc', True))]
+
+        # test values
+        assert cluster.dbc_attributes['BusType'] == ('CAN', True)
+        assert cluster.dbc_attributes['NetworkAttr1'] == ('abc', True)
+
+
+@pytest.mark.integration
+def test_ecu_dbc_attributes():
+    database_filepath = os.path.join(os.path.dirname(__file__), 'databases\\attributes.dbc')
+    with database.Database(database_filepath) as db:
+        cluster = db.clusters['Cluster']
+        ecu1 = cluster.ecus['ECU1']
+        ecu2 = cluster.ecus['ECU2']
+
+        # test dunders
+        assert len(ecu1.dbc_attributes) == 1
+        assert len({ecu1.dbc_attributes, ecu1.dbc_attributes}) == 1  # testing `__hash__`
+        assert len({ecu1.dbc_attributes, ecu2.dbc_attributes}) == 2  # testing `__hash__`
+        assert ecu1.dbc_attributes == ecu1.dbc_attributes
+        assert ecu1.dbc_attributes != ecu2.dbc_attributes
+        for key in ecu1.dbc_attributes:
+            print(ecu1.dbc_attributes[key])
+
+        # test mapping overrides
+        assert sorted(ecu1.dbc_attributes.keys()) == ['EcuAttr1']
+        assert sorted(ecu1.dbc_attributes.items()) == [('EcuAttr1', ('xEcu1', True))]
+        assert sorted(ecu1.dbc_attributes.values()) == [('xEcu1', True)]
+
+        # test values
+        assert ecu1.dbc_attributes['EcuAttr1'] == ('xEcu1', True)
+        assert ecu2.dbc_attributes['EcuAttr1'] == ('xEcu2-Set', False)
+
+
+@pytest.mark.integration
+def test_frame_dbc_attributes():
+    database_filepath = os.path.join(os.path.dirname(__file__), 'databases\\attributes.dbc')
+    with database.Database(database_filepath) as db:
+        cluster = db.clusters['Cluster']
+        frame1 = cluster.frames['Msg1']
+        frame2 = cluster.frames['Msg2']
+
+        # test dunders
+        assert len(frame1.dbc_attributes) == 4
+        assert len({frame1.dbc_attributes, frame1.dbc_attributes}) == 1  # testing `__hash__`
+        assert len({frame1.dbc_attributes, frame2.dbc_attributes}) == 2  # testing `__hash__`
+        assert frame1.dbc_attributes == frame1.dbc_attributes
+        assert frame1.dbc_attributes != frame2.dbc_attributes
+        for key in frame1.dbc_attributes:
+            print(frame1.dbc_attributes[key])
+
+        # test mapping overrides
+        assert sorted(frame1.dbc_attributes.keys()) == ['MsgAttr1', 'MsgAttr2', 'MsgAttr3', 'MsgAttr4']
+        assert sorted(frame1.dbc_attributes.values()) == [('-11.1', True),
+                                                          ('2', True),
+                                                          ('2', True),
+                                                          ('DefaultMsgAttr3String', True)]
+        assert sorted(frame1.dbc_attributes.items()) == [('MsgAttr1', ('2', True)),
+                                                         ('MsgAttr2', ('-11.1', True)),
+                                                         ('MsgAttr3', ('DefaultMsgAttr3String', True)),
+                                                         ('MsgAttr4', ('2', True))]
+
+        # test values
+        assert frame1.dbc_attributes['MsgAttr1'] == ('2', True)
+        assert frame1.dbc_attributes['MsgAttr2'] == ('-11.1', True)
+        assert frame1.dbc_attributes['MsgAttr3'] == ('DefaultMsgAttr3String', True)
+        assert frame1.dbc_attributes['MsgAttr4'] == ('2', True)
+        assert frame2.dbc_attributes['MsgAttr1'] == ('22', False)
+        assert frame2.dbc_attributes['MsgAttr2'] == ('-23.33', False)
+        assert frame2.dbc_attributes['MsgAttr3'] == ('MsgAttr3String', False)
+        assert frame2.dbc_attributes['MsgAttr4'] == ('1', False)
+
+
+@pytest.mark.integration
+def test_signal_dbc_attributes():
+    database_filepath = os.path.join(os.path.dirname(__file__), 'databases\\attributes.dbc')
+    with database.Database(database_filepath) as db:
+        cluster = db.clusters['Cluster']
+        frame1 = cluster.frames['Msg1']
+        sig1 = frame1.mux_static_signals['Sig1']
+        sig2 = frame1.mux_static_signals['Sig2']
+
+        # test dunders
+        assert len(sig1.dbc_attributes) == 1
+        assert len({sig1.dbc_attributes, sig1.dbc_attributes}) == 1  # testing `__hash__`
+        assert len({sig1.dbc_attributes, sig2.dbc_attributes}) == 2  # testing `__hash__`
+        assert sig1.dbc_attributes == sig1.dbc_attributes
+        assert sig1.dbc_attributes != sig2.dbc_attributes
+        for key in sig1.dbc_attributes:
+            print(sig1.dbc_attributes[key])
+
+        # test mapping overrides
+        assert sorted(sig2.dbc_attributes.keys()) == ['SigAttr1']
+        assert sorted(sig2.dbc_attributes.values()) == [('11', False)]
+        assert sorted(sig2.dbc_attributes.items()) == [('SigAttr1', ('11', False))]
+
+        # test values
+        assert sig1.dbc_attributes['SigAttr1'] == ('1', True)
+        assert sig2.dbc_attributes['SigAttr1'] == ('11', False)


### PR DESCRIPTION
Add get_dbc_attribute method for cluster,
frame, ECU, and signal objects.

Add tests and a DBC containing attributes.

- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nixnet-python/blob/master/CONTRIBUTING.rst).
- [X] New tests have been created for any new features or regression tests for bugfixes.
- [X] `tox` successfully runs, including unit tests and style checks (see [CONTRIBUTING.md](https://github.com/ni/nixnet-python/blob/master/CONTRIBUTING.rst)).