### PR TITLE
chore(examples): Rename in-memory db in examples.

### DIFF
--- a/nixnet_examples/can_dynamic_database_creation.py
+++ b/nixnet_examples/can_dynamic_database_creation.py
@@ -12,7 +12,7 @@ from nixnet import database
 
 
 def main():
-    database_name = ':memory:'
+    database_name = ':CAN_Database:'
     cluster_name = 'CAN_Cluster'
     frame_name = 'CAN_Event_Frame'
     signal_1_name = 'CAN_Event_Signal_1'
@@ -21,7 +21,7 @@ def main():
     output_interface = 'CAN1'
     input_interface = 'CAN2'
 
-    # Open the default in-memory database.
+    # Open an in-memory database.
     with database.Database(database_name) as db:
 
         # Add a CAN cluster, a frame, and two signals to the database.

--- a/nixnet_examples/lin_dynamic_database_creation.py
+++ b/nixnet_examples/lin_dynamic_database_creation.py
@@ -12,7 +12,7 @@ from nixnet import database
 
 
 def main():
-    database_name = ':memory:'
+    database_name = ':LIN_Database:'
     cluster_name = 'LIN_Cluster'
     ecu_1_name = 'LIN_ECU_1'
     ecu_2_name = 'LIN_ECU_2'
@@ -25,7 +25,7 @@ def main():
     output_interface = 'LIN1'
     input_interface = 'LIN2'
 
-    # Open the default in-memory database.
+    # Open an in-memory database.
     with database.Database(database_name) as db:
 
         # Add a LIN cluster, a frame, and two signals to the database.


### PR DESCRIPTION
In our examples, make it clear that in-memory
databases are not restricted to ':memory:'.

Also, it's probably better to avoid using
':memory:' for in-memory databases in case
that might cause conflict with the stream sessions.

- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nixnet-python/blob/master/CONTRIBUTING.rst).
- [x] New tests have been created for any new features or regression tests for bugfixes.
- [x] `tox` successfully runs, including unit tests and style checks (see [CONTRIBUTING.md](https://github.com/ni/nixnet-python/blob/master/CONTRIBUTING.rst)).