### PR TITLE
refactor(API): have config_status return status code and text.

### DIFF
--- a/nixnet/_errors.py
+++ b/nixnet/_errors.py
@@ -7,22 +7,24 @@ import warnings
 
 from nixnet import _cconsts
 from nixnet import _cfuncs
+from nixnet import _ctypedefs
 from nixnet import errors
 
 
 def check_for_error(error_code):
     if error_code & _cconsts.NX_STATUS_ERROR:
-        buffer_size = 2048
-        error_buffer = ctypes.create_string_buffer(buffer_size)
-
-        _cfuncs.lib.nx_status_to_string(error_code, buffer_size, error_buffer)
-
-        raise errors.XnetError(error_buffer.value.decode("ascii"), error_code)
+        status = status_to_string(error_code)
+        raise errors.XnetError(status, error_code)
     elif error_code != _cconsts.NX_SUCCESS:
-        buffer_size = 2048
-        error_buffer = ctypes.create_string_buffer(buffer_size)
+        status = status_to_string(error_code)
+        warnings.warn(errors.XnetWarning(status, error_code))
 
-        _cfuncs.lib.nx_status_to_string(error_code, buffer_size, error_buffer)
 
-        warnings.warn(errors.XnetWarning(
-            error_buffer.value.decode("ascii"), error_code))
+def status_to_string(status_code):
+    buffer_size = 2048
+    buffer_size_ctypes = _ctypedefs.u32(buffer_size)
+    buffer_ctypes = ctypes.create_string_buffer(buffer_size)
+    status_code_ctypes = _ctypedefs.nxStatus_t(status_code)
+    _cfuncs.lib.nx_status_to_string(status_code_ctypes, buffer_size_ctypes, buffer_ctypes)
+    status_string = buffer_ctypes.value.decode("ascii")
+    return status_string

--- a/nixnet/_errors.py
+++ b/nixnet/_errors.py
@@ -13,11 +13,15 @@ from nixnet import errors
 
 def check_for_error(error_code):
     if error_code & _cconsts.NX_STATUS_ERROR:
-        status = status_to_string(error_code)
-        raise errors.XnetError(status, error_code)
+        raise_xnet_error(error_code)
     elif error_code != _cconsts.NX_SUCCESS:
         status = status_to_string(error_code)
         warnings.warn(errors.XnetWarning(status, error_code))
+
+
+def raise_xnet_error(error_code):
+    status = status_to_string(error_code)
+    raise errors.XnetError(status, error_code)
 
 
 def status_to_string(status_code):

--- a/nixnet/_funcs.py
+++ b/nixnet/_funcs.py
@@ -144,7 +144,7 @@ def nx_read_state(
     state_size,  # type: int
     state_value_ctypes_ptr,  # type: typing.Any
 ):
-    # type: (...) -> typing.Tuple[typing.Any, int]
+    # type: (...) -> int
     session_ref_ctypes = _ctypedefs.nxSessionRef_t(session_ref)
     state_id_ctypes = _ctypedefs.u32(state_id.value)
     state_size_ctypes = _ctypedefs.u32(state_size)

--- a/nixnet/_utils.py
+++ b/nixnet/_utils.py
@@ -28,8 +28,7 @@ def flatten_items(list):
         # For FRAME_IN_QUEUED / FRAME_OUT_QUEUED
         # Convenience for everything else
         if ',' in list:
-            # A bit of an abuse of an error code
-            _errors.check_for_error(_cconsts.NX_ERR_INVALID_PROPERTY_VALUE)
+            _errors.raise_xnet_error(_cconsts.NX_ERR_INVALID_PROPERTY_VALUE)
         flattened = list
     elif isinstance(list, collections.Iterable):
         flattened = ",".join(list)
@@ -37,8 +36,7 @@ def flatten_items(list):
         # For FRAME_IN_STREAM / FRAME_OUT_STREAM
         flattened = ''
     else:
-        # A bit of an abuse of an error code
-        _errors.check_for_error(_cconsts.NX_ERR_INVALID_PROPERTY_VALUE)
+        _errors.raise_xnet_error(_cconsts.NX_ERR_INVALID_PROPERTY_VALUE)
 
     return flattened
 

--- a/nixnet/_utils.py
+++ b/nixnet/_utils.py
@@ -14,7 +14,7 @@ from nixnet import types
 
 
 def flatten_items(list):
-    # (typing.Union[typing.Text, typing.List[typing.Text]]) -> typing.Text
+    # type: (typing.Union[typing.Text, typing.List[typing.Text]]) -> typing.Text
     """Flatten an item list to a string
 
     >>> str(flatten_items('Item'))
@@ -42,7 +42,7 @@ def flatten_items(list):
 
 
 def parse_can_comm_bitfield(bitfield):
-    # (int) -> types.CanComm
+    # type:  (int) -> types.CanComm
     """Parse a CAN Comm bitfield."""
     state = constants.CanCommState(bitfield & 0x0F)
     tcvr_err = ((bitfield >> 4) & 0x01) != 0
@@ -54,7 +54,7 @@ def parse_can_comm_bitfield(bitfield):
 
 
 def parse_lin_comm_bitfield(first, second):
-    # (int) -> types.CanComm
+    # type: (int, int) -> types.LinComm
     """Parse a LIN Comm first."""
     sleep = ((first >> 1) & 0x01) != 0
     state = constants.LinCommState((first >> 2) & 0x03)

--- a/nixnet/database/_cluster.py
+++ b/nixnet/database/_cluster.py
@@ -54,6 +54,23 @@ class Cluster(object):
     def __repr__(self):
         return '{}(handle={})'.format(type(self).__name__, self._handle)
 
+    def check_config_status(self):
+        # type: () -> None
+        """Check this cluster's configuration status.
+
+        By default, incorrectly configured clusters in the database are not returned from
+        :any:`Database.clusters` because they cannot be used in the bus communication.
+        You can change this behavior by setting :any:`Database.show_invalid_from_open` to `True`.
+        When a cluster configuration status becomes invalid after the database is opened,
+        the cluster still is returned from :any:`Database.clusters`
+        even if :any:`Database.show_invalid_from_open` is `False`.
+
+        Raises:
+            XnetError: The cluster is incorrectly configured.
+        """
+        status_code = _props.get_cluster_config_status(self._handle)
+        _errors.check_for_error(status_code)
+
     def export(self, db_filepath):
         # type: (typing.Text) -> None
         """Exports this cluster to a CANdb++ or LIN database file format.
@@ -180,13 +197,6 @@ class Cluster(object):
     def comment(self, value):
         # type: (typing.Text) -> None
         _props.set_cluster_comment(self._handle, value)
-
-    @property
-    def config_status(self):
-        # type: () -> typing.Tuple[int, typing.Text]
-        status_code = _props.get_cluster_config_status(self._handle)
-        status_text = _errors.status_to_string(status_code)
-        return status_code, status_text
 
     @property
     def database_ref(self):

--- a/nixnet/database/_cluster.py
+++ b/nixnet/database/_cluster.py
@@ -5,6 +5,7 @@ from __future__ import print_function
 import typing  # NOQA: F401
 
 from nixnet import _cconsts
+from nixnet import _errors
 from nixnet import _funcs
 from nixnet import _props
 from nixnet import constants
@@ -182,21 +183,10 @@ class Cluster(object):
 
     @property
     def config_status(self):
-        # type: () -> int
-        """int: Returns the cluster object configuration status.
-
-        Configuration Status returns an NI-XNET error code.
-        You can pass the value to the `nxStatusToString` function to
-        convert the value to a text description of the configuration problem.
-
-        By default, incorrectly configured clusters in the database are not returned from
-        :any:`Database.clusters` because they cannot be used in the bus communication.
-        You can change this behavior by setting :any:`Database.show_invalid_from_open` to ``True``.
-        When the configuration status of a cluster becomes invalid after the database has been opened,
-        the cluster still is returned from :any:`Database.clusters` even if
-        :any:`Database.show_invalid_from_open` to ``False``.
-        """
-        return _props.get_cluster_config_status(self._handle)
+        # type: () -> typing.Tuple[int, typing.Text]
+        status_code = _props.get_cluster_config_status(self._handle)
+        status_text = _errors.status_to_string(status_code)
+        return status_code, status_text
 
     @property
     def database_ref(self):

--- a/nixnet/database/_ecu.py
+++ b/nixnet/database/_ecu.py
@@ -40,6 +40,23 @@ class Ecu(object):
     def __repr__(self):
         return '{}(handle={})'.format(type(self).__name__, self._handle)
 
+    def check_config_status(self):
+        # type: () -> None
+        """Check this ECU's configuration status.
+
+        By default, incorrectly configured ECUs in the database are not returned from
+        :any:`Cluster.ecus` because they cannot be used in the bus communication.
+        You can change this behavior by setting :any:`Database.show_invalid_from_open` to `True`.
+        When an ECU configuration status becomes invalid after the database is opened,
+        the ECU still is returned from :any:`Cluster.ecus`
+        even if :any:`Database.show_invalid_from_open` is `False`.
+
+        Raises:
+            XnetError: The ECU is incorrectly configured.
+        """
+        status_code = _props.get_ecu_config_status(self._handle)
+        _errors.check_for_error(status_code)
+
     @property
     def clst(self):
         # type: () -> _cluster.Cluster
@@ -64,13 +81,6 @@ class Ecu(object):
     def comment(self, value):
         # type: (typing.Text) -> None
         _props.set_ecu_comment(self._handle, value)
-
-    @property
-    def config_status(self):
-        # type: () -> typing.Tuple[int, typing.Text]
-        status_code = _props.get_ecu_config_status(self._handle)
-        status_text = _errors.status_to_string(status_code)
-        return status_code, status_text
 
     @property
     def dbc_attributes(self):

--- a/nixnet/database/_ecu.py
+++ b/nixnet/database/_ecu.py
@@ -4,6 +4,7 @@ from __future__ import print_function
 
 import typing  # NOQA: F401
 
+from nixnet import _errors
 from nixnet import _props
 from nixnet import constants
 
@@ -66,21 +67,10 @@ class Ecu(object):
 
     @property
     def config_status(self):
-        # type: () -> int
-        """int: Returns the ECU object configuration status.
-
-        Configuration Status returns an NI-XNET error code.
-        You can pass the value to the `nxStatusToString` function to
-        convert the value to a text description of the configuration problem.
-
-        By default, incorrectly configured ECUs in the database are not returned from
-        :any:`Cluster.ecus` because they cannot be used in the bus communication.
-        You can change this behavior by setting :any:`Database.show_invalid_from_open` to ``True``.
-        When the configuration status of a ECU becomes invalid after opening the database,
-        the ECU still is returned from :any:`Cluster.ecus`
-        even if :any:`Database.show_invalid_from_open` is ``False``.
-        """
-        return _props.get_ecu_config_status(self._handle)
+        # type: () -> typing.Tuple[int, typing.Text]
+        status_code = _props.get_ecu_config_status(self._handle)
+        status_text = _errors.status_to_string(status_code)
+        return status_code, status_text
 
     @property
     def dbc_attributes(self):

--- a/nixnet/database/_frame.py
+++ b/nixnet/database/_frame.py
@@ -521,8 +521,8 @@ class Frame(object):
         """
         ref = _props.get_frame_mux_data_mux_sig_ref(self._handle)
         if ref == 0:
-            # A bit of an abuse of errors
-            _errors.check_for_error(_cconsts.NX_ERR_SIGNAL_NOT_FOUND)
+            _errors.raise_xnet_error(_cconsts.NX_ERR_SIGNAL_NOT_FOUND)
+
         return _signal.Signal(ref)
 
     @property

--- a/nixnet/database/_frame.py
+++ b/nixnet/database/_frame.py
@@ -84,21 +84,10 @@ class Frame(object):
 
     @property
     def config_status(self):
-        # type: () -> int
-        """int: Returns the frame object configuration status.
-
-        Configuration Status returns an NI-XNET error code.
-        You can pass the value to the `nxStatusToString` function to
-        convert the value to a text description of the configuration problem.
-
-        By default, incorrectly configured frames in the database are not returned from
-        :any:`Cluster.frames` because they cannot be used in the bus communication.
-        You can change this behavior by setting :any:`Database.show_invalid_from_open` to ``True``.
-        When the configuration status of a frames becomes invalid after opening the database,
-        the frame still is returned from :any:`Cluster.frames`
-        even if :any:`Database.show_invalid_from_open` is ``False``.
-        """
-        return _props.get_frame_config_status(self._handle)
+        # type: () -> typing.Tuple[int, typing.Text]
+        status_code = _props.get_frame_config_status(self._handle)
+        status_text = _errors.status_to_string(status_code)
+        return status_code, status_text
 
     @property
     def default_payload(self):

--- a/nixnet/database/_lin_sched.py
+++ b/nixnet/database/_lin_sched.py
@@ -5,6 +5,7 @@ from __future__ import print_function
 import typing  # NOQA: F401
 
 from nixnet import _cconsts
+from nixnet import _errors
 from nixnet import _props
 from nixnet import constants
 
@@ -70,24 +71,10 @@ class LinSched(object):
 
     @property
     def config_status(self):
-        # type: () -> int
-        """int: Returns the LIN schedule object configuration status.
-
-        Configuration Status returns an NI-XNET error code.
-        You can pass the value to the `nxStatusToString` function to
-        convert the value to a text description of the configuration problem.
-
-        By default, incorrectly configured schedules in the database are not returned from
-        :any:`Cluster.lin_schedules` because they cannot be used in the bus communication.
-        You can change this behavior by setting :any:`Database.show_invalid_from_open` to ``True``.
-        When the configuration status of a schedule becomes invalid after opening the database,
-        the schedule still is returned from :any:`Cluster.lin_schedules`
-        even if :any:`Database.show_invalid_from_open` is ``False``.
-
-        An example of invalid schedule configuration is when a required schedule property has not been defined.
-        For example, a schedule entry within this schedule has an undefined delay time.
-        """
-        return _props.get_lin_sched_config_status(self._handle)
+        # type: () -> typing.Tuple[int, typing.Text]
+        status_code = _props.get_lin_sched_config_status(self._handle)
+        status_text = _errors.status_to_string(status_code)
+        return status_code, status_text
 
     @property
     def entries(self):

--- a/nixnet/database/_lin_sched.py
+++ b/nixnet/database/_lin_sched.py
@@ -45,6 +45,23 @@ class LinSched(object):
     def __repr__(self):
         return '{}(handle={})'.format(type(self).__name__, self._handle)
 
+    def check_config_status(self):
+        # type: () -> None
+        """Check this LIN schedule's configuration status.
+
+        By default, incorrectly configured schedules in the database are not returned from
+        :any:`Cluster.lin_schedules` because they cannot be used in the bus communication.
+        You can change this behavior by setting :any:`Database.show_invalid_from_open` to `True`.
+        When a schedule configuration status becomes invalid after the database is opened,
+        the schedule still is returned from :any:`Cluster.lin_schedules`
+        even if :any:`Database.show_invalid_from_open` is `False`.
+
+        Raises:
+            XnetError: The LIN schedule is incorrectly configured.
+        """
+        status_code = _props.get_lin_sched_config_status(self._handle)
+        _errors.check_for_error(status_code)
+
     @property
     def clst(self):
         # type: () -> _cluster.Cluster
@@ -68,13 +85,6 @@ class LinSched(object):
     def comment(self, value):
         # type: (typing.Text) -> None
         _props.set_lin_sched_comment(self._handle, value)
-
-    @property
-    def config_status(self):
-        # type: () -> typing.Tuple[int, typing.Text]
-        status_code = _props.get_lin_sched_config_status(self._handle)
-        status_text = _errors.status_to_string(status_code)
-        return status_code, status_text
 
     @property
     def entries(self):

--- a/nixnet/database/_lin_sched_entry.py
+++ b/nixnet/database/_lin_sched_entry.py
@@ -53,8 +53,8 @@ class LinSchedEntry(object):
         """
         handle = _props.get_lin_sched_entry_collision_res_sched(self._handle)
         if handle == 0:
-            # A bit of an abuse of errors
-            _errors.check_for_error(_cconsts.NX_ERR_DATABASE_OBJECT_NOT_FOUND)
+            _errors.raise_xnet_error(_cconsts.NX_ERR_DATABASE_OBJECT_NOT_FOUND)
+
         return _lin_sched.LinSched(handle)
 
     @collision_res_sched.setter

--- a/nixnet/database/_pdu.py
+++ b/nixnet/database/_pdu.py
@@ -81,21 +81,10 @@ class Pdu(object):
 
     @property
     def config_status(self):
-        # type: () -> int
-        """int: Returns the PDU object configuration status.
-
-        Configuration Status returns an NI-XNET error code.
-        You can pass the value to the `nxStatusToString` function to
-        convert the value to a text description of the configuration problem.
-
-        By default, incorrectly configured frames in the database are not returned from
-        :any:`Cluster.frames` because they cannot be used in the bus communication.
-        You can change this behavior by setting :any:`Database.show_invalid_from_open` to ``True``.
-        When the configuration status of a frames becomes invalid after opening the database,
-        the frame still is returned from :any:`Cluster.frames`
-        even if :any:`Database.show_invalid_from_open` is ``False``.
-        """
-        return _props.get_pdu_config_status(self._handle)
+        # type: () -> typing.Tuple[int, typing.Text]
+        status_code = _props.get_pdu_config_status(self._handle)
+        status_text = _errors.status_to_string(status_code)
+        return status_code, status_text
 
     @property
     def frms(self):

--- a/nixnet/database/_pdu.py
+++ b/nixnet/database/_pdu.py
@@ -201,8 +201,8 @@ class Pdu(object):
         """
         handle = _props.get_pdu_mux_data_mux_sig_ref(self._handle)
         if handle == 0:
-            # A bit of an abuse of errors
-            _errors.check_for_error(_cconsts.NX_ERR_SIGNAL_NOT_FOUND)
+            _errors.raise_xnet_error(_cconsts.NX_ERR_SIGNAL_NOT_FOUND)
+
         return _signal.Signal(handle)
 
     @property

--- a/nixnet/database/_pdu.py
+++ b/nixnet/database/_pdu.py
@@ -47,6 +47,23 @@ class Pdu(object):
     def __repr__(self):
         return '{}(handle={})'.format(type(self).__name__, self._handle)
 
+    def check_config_status(self):
+        # type: () -> None
+        """Check this PDU's configuration status.
+
+        By default, incorrectly configured PDUs in the database are not returned from
+        :any:`Cluster.pdus` because they cannot be used in the bus communication.
+        You can change this behavior by setting :any:`Database.show_invalid_from_open` to `True`.
+        When a PDU configuration status becomes invalid after the database is opened,
+        the PDU still is returned from :any:`Cluster.pdus`
+        even if :any:`Database.show_invalid_from_open` is `False`.
+
+        Raises:
+            XnetError: The PDU is incorrectly configured.
+        """
+        status_code = _props.get_pdu_config_status(self._handle)
+        _errors.check_for_error(status_code)
+
     @property
     def cluster(self):
         # type: () -> _cluster.Cluster
@@ -78,13 +95,6 @@ class Pdu(object):
     def comment(self, value):
         # type: (typing.Text) -> None
         _props.set_pdu_comment(self._handle, value)
-
-    @property
-    def config_status(self):
-        # type: () -> typing.Tuple[int, typing.Text]
-        status_code = _props.get_pdu_config_status(self._handle)
-        status_text = _errors.status_to_string(status_code)
-        return status_code, status_text
 
     @property
     def frms(self):

--- a/nixnet/database/_signal.py
+++ b/nixnet/database/_signal.py
@@ -496,6 +496,6 @@ class Signal(object):
         from nixnet.database import _subframe
         ref = _props.get_signal_mux_subfrm_ref(self._handle)
         if ref == 0:
-            # A bit of an abuse of errors
-            _errors.check_for_error(_cconsts.NX_ERR_FRAME_NOT_FOUND)
+            _errors.raise_xnet_error(_cconsts.NX_ERR_FRAME_NOT_FOUND)
+
         return _subframe.SubFrame(ref)

--- a/nixnet/database/_signal.py
+++ b/nixnet/database/_signal.py
@@ -87,21 +87,10 @@ class Signal(object):
 
     @property
     def config_status(self):
-        # type: () -> int
-        """int: Returns the signal object configuration status.
-
-        Configuration Status returns an NI-XNET error code.
-        You can pass the value to the `nxStatusToString` function to
-        convert the value to a text description of the configuration problem.
-
-        By default, incorrectly configured signals in the database are not returned from
-        :any:`Frame.sigs` because they cannot be used in the bus communication.
-        You can change this behavior by setting :any:`Database.show_invalid_from_open` to ``True``.
-        When the configuration status of a signal becomes invalid after opening the database,
-        the signal still is returned from :any:`Frame.sigs`
-        even if :any:`Database.show_invalid_from_open` is ``False``.
-        """
-        return _props.get_signal_config_status(self._handle)
+        # type: () -> typing.Tuple[int, typing.Text]
+        status_code = _props.get_signal_config_status(self._handle)
+        status_text = _errors.status_to_string(status_code)
+        return status_code, status_text
 
     @property
     def data_type(self):

--- a/nixnet/database/_subframe.py
+++ b/nixnet/database/_subframe.py
@@ -5,6 +5,7 @@ from __future__ import print_function
 import typing  # NOQA: F401
 
 from nixnet import _cconsts
+from nixnet import _errors
 from nixnet import _props
 from nixnet import constants
 
@@ -43,21 +44,10 @@ class SubFrame(object):
 
     @property
     def config_status(self):
-        # type: () -> int
-        """int: Returns the subframe object configuration status.
-
-        Configuration Status returns an NI-XNET error code.
-        You can pass the value to the `nxStatusToString` function to
-        convert the value to a text description of the configuration problem.
-
-        By default, incorrectly configured subframes in the database are not returned from
-        :any:`Frame.mux_subframes` because they cannot be used in the bus communication.
-        You can change this behavior by setting :any:`Database.show_invalid_from_open` to ``True``.
-        When the configuration status of a subframe becomes invalid after opening the database,
-        the subframe still is returned from :any:`Frame.mux_subframes`
-        even if :any:`Database.show_invalid_from_open` is ``False``.
-        """
-        return _props.get_subframe_config_status(self._handle)
+        # type: () -> typing.Tuple[int, typing.Text]
+        status_code = _props.get_subframe_config_status(self._handle)
+        status_text = _errors.status_to_string(status_code)
+        return status_code, status_text
 
     @property
     def dyn_signals(self):

--- a/nixnet/database/_subframe.py
+++ b/nixnet/database/_subframe.py
@@ -42,12 +42,22 @@ class SubFrame(object):
     def __repr__(self):
         return '{}(handle={})'.format(type(self).__name__, self._handle)
 
-    @property
-    def config_status(self):
-        # type: () -> typing.Tuple[int, typing.Text]
+    def check_config_status(self):
+        # type: () -> None
+        """Check this subframe's configuration status.
+
+        By default, incorrectly configured subframes in the database are not returned from
+        :any:`Frame.mux_subframes` because they cannot be used in the bus communication.
+        You can change this behavior by setting :any:`Database.show_invalid_from_open` to `True`.
+        When a subframe configuration status becomes invalid after the database is opened,
+        the subframe still is returned from :any:`Frame.mux_subframes`
+        even if :any:`Database.show_invalid_from_open` is `False`.
+
+        Raises:
+            XnetError: The subframe is incorrectly configured.
+        """
         status_code = _props.get_subframe_config_status(self._handle)
-        status_text = _errors.status_to_string(status_code)
-        return status_code, status_text
+        _errors.check_for_error(status_code)
 
     @property
     def dyn_signals(self):

--- a/nixnet/database/database.py
+++ b/nixnet/database/database.py
@@ -179,10 +179,10 @@ class Database(object):
         (for example, :any:`Cluster.frames` and :any:`Frame.mux_static_signals`).
 
         For invalid objects,
-        the :any:`Cluster.config_status`,
-        :any:`Frame.config_status`,
-        and :any:`Signal.config_status` properties return an error code that explains the problem.
-        For valid objects, Configuration Status returns success (no error).
+        the :any:`Cluster.check_config_status`,
+        :any:`Frame.check_config_status`,
+        and :any:`Signal.check_config_status` methods raise an exception if there is a problem.
+        For valid objects, no error is raised.
 
         :any:`Cluster`, :any:`Frame<_frame.Frame>`, and :any:`Signal<_signal.Signal>` objects that became
         invalid after the database is opened are still returned from the
@@ -191,7 +191,8 @@ class Database(object):
         and Configuration Status returns an error code.
         For example, if you open a :any:`Frame<_frame.Frame>` with valid properties,
         then you set :any:`Signal.start_bit` beyond the :any:`Frame.payload_len`,
-        the :any:`Frame.config_status` returns an error, but the frame is returned from :any:`Cluster.frames`.
+        :any:`Frame.check_config_status` raises an exception,
+        but the frame is returned from :any:`Cluster.frames`.
         """
         return _props.get_database_show_invalid_from_open(self._handle)
 

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -3,22 +3,22 @@ from __future__ import division
 from __future__ import print_function
 
 import mock  # type: ignore
+import pytest  # type: ignore
 import time
 
-import pytest  # type: ignore
-
 import nixnet
+from nixnet import _cfuncs
+from nixnet import _ctypedefs
 from nixnet import _utils
 from nixnet import constants
 from nixnet import errors
 from nixnet import types
 
+MockXnetLibrary = mock.create_autospec(_cfuncs.XnetLibrary, spec_set=True, instance=True)
+MockXnetLibrary.nx_status_to_string.return_value = _ctypedefs.u32(0)
 
-def raise_code(code):
-    raise errors.XnetError("", code)
 
-
-@mock.patch('nixnet._errors.check_for_error', raise_code)
+@mock.patch('nixnet._cfuncs.lib', MockXnetLibrary)
 def test_flatten_items_invalid():
     with pytest.raises(errors.XnetError):
         _utils.flatten_items('A,B')


### PR DESCRIPTION
BREAKING CHANGE:

Before, we just returned the status code.
However, the user previously had no way to get the text for the status code.
Now, return the status code and text in a tuple.

- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nixnet-python/blob/master/CONTRIBUTING.rst).
- [x] New tests have been created for any new features or regression tests for bugfixes.
- [x] `tox` successfully runs, including unit tests and style checks (see [CONTRIBUTING.md](https://github.com/ni/nixnet-python/blob/master/CONTRIBUTING.rst)).