### PR TITLE
chore(API): Improve parameter names on __exit__.

### DIFF
--- a/nixnet/_session/base.py
+++ b/nixnet/_session/base.py
@@ -76,7 +76,7 @@ class SessionBase(object):
     def __enter__(self):
         return self
 
-    def __exit__(self, type, value, traceback):
+    def __exit__(self, exception_type, exception_value, traceback):
         self.close()
 
     def __eq__(self, other):

--- a/nixnet/convert.py
+++ b/nixnet/convert.py
@@ -88,7 +88,7 @@ class SignalConversionSinglePointSession(object):
     def __enter__(self):
         return self
 
-    def __exit__(self, type, value, traceback):
+    def __exit__(self, exception_type, exception_value, traceback):
         self.close()
 
     def __eq__(self, other):

--- a/nixnet/database/database.py
+++ b/nixnet/database/database.py
@@ -45,7 +45,7 @@ class Database(object):
     def __enter__(self):
         return self
 
-    def __exit__(self, type, value, traceback):
+    def __exit__(self, exception_type, exception_value, traceback):
         self.close()
 
     def __eq__(self, other):

--- a/nixnet/system/system.py
+++ b/nixnet/system/system.py
@@ -49,7 +49,7 @@ class System(object):
     def __enter__(self):
         return self
 
-    def __exit__(self, type, value, traceback):
+    def __exit__(self, exception_type, exception_value, traceback):
         self.close()
 
     def __eq__(self, other):


### PR DESCRIPTION
`__exit__` parameter 'type' shadows a built-in name.
I like the descriptive naming chosen [here](http://docs.quantifiedcode.com/python-anti-patterns/correctness/exit_must_accept_three_arguments.html).

- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nixnet-python/blob/master/CONTRIBUTING.rst).
- [x] New tests have been created for any new features or regression tests for bugfixes.
- [x] `tox` successfully runs, including unit tests and style checks (see [CONTRIBUTING.md](https://github.com/ni/nixnet-python/blob/master/CONTRIBUTING.rst)).