### PR TITLE
fix(API): DBC signal values are integers.

### DIFF
--- a/nixnet/database/_dbc_signal_value_table.py
+++ b/nixnet/database/_dbc_signal_value_table.py
@@ -43,7 +43,7 @@ class DbcSignalValueTable(collections.Mapping):
         return self.keys()
 
     def __getitem__(self, key):
-        # type: (typing.Text) -> typing.Text
+        # type: (typing.Text) -> int
         """Return the value.
 
             Args:
@@ -82,7 +82,7 @@ class DbcSignalValueTable(collections.Mapping):
 
     @property
     def _value_table(self):
-        # type: () -> typing.Dict[typing.Text, typing.Text]
+        # type: () -> typing.Dict[typing.Text, int]
         mode = constants.GetDbcAttributeMode.VALUE_TABLE_LIST
         attribute_size = _funcs.nxdb_get_dbc_attribute_size(self._handle, mode, '')
         attribute_info = _funcs.nxdb_get_dbc_attribute(self._handle, mode, '', attribute_size)
@@ -97,6 +97,6 @@ class DbcSignalValueTable(collections.Mapping):
         # table_string is of the format 'value1, key1, value2, key2, ...'
         # convert to a dict: { 'key1': int('value1'), 'key2': int('value2'), ... }
         table_dict = dict(
-            (key, value)
+            (key, int(value))
             for value, key in zip(table_list[0::2], table_list[1::2]))
         return table_dict

--- a/tests/test_dbc_signal_value_table.py
+++ b/tests/test_dbc_signal_value_table.py
@@ -62,10 +62,10 @@ def test_signal_dbc_signal_value_table():
 
         # test container
         assert sorted(sig1.dbc_signal_value_table.keys()) == ['High', 'Low', 'Zero']
-        assert sorted(sig1.dbc_signal_value_table.values()) == ['-10', '0', '4']
-        assert sorted(sig1.dbc_signal_value_table.items()) == [('High', '4'), ('Low', '-10'), ('Zero', '0')]
+        assert sorted(sig1.dbc_signal_value_table.values()) == [-10, 0, 4]
+        assert sorted(sig1.dbc_signal_value_table.items()) == [('High', 4), ('Low', -10), ('Zero', 0)]
 
         # test values
-        assert sig1.dbc_signal_value_table['Low'] == '-10'
-        assert sig1.dbc_signal_value_table['High'] == '4'
-        assert sig1.dbc_signal_value_table['Zero'] == '0'
+        assert sig1.dbc_signal_value_table['Low'] == -10
+        assert sig1.dbc_signal_value_table['High'] == 4
+        assert sig1.dbc_signal_value_table['Zero'] == 0


### PR DESCRIPTION
Fixes #229

BREAKING CHANGE:

DBC signal value is now int instead of string.

- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nixnet-python/blob/master/CONTRIBUTING.rst).
- [x] New tests have been created for any new features or regression tests for bugfixes.
- [x] `tox` successfully runs, including unit tests and style checks (see [CONTRIBUTING.md](https://github.com/ni/nixnet-python/blob/master/CONTRIBUTING.rst)).