### PR TITLE
feat(API): Add descendant find for parent db objects.

### DIFF
--- a/docs/api_reference/database/lin_sched.rst
+++ b/docs/api_reference/database/lin_sched.rst
@@ -1,5 +1,5 @@
-nixnet.database.linsched
-========================
+nixnet.database.lin_sched
+=========================
 
 .. automodule:: nixnet.database._lin_sched
     :members:

--- a/docs/api_reference/database/lin_sched_entry.rst
+++ b/docs/api_reference/database/lin_sched_entry.rst
@@ -1,5 +1,5 @@
-nixnet.database.linsched_entry
-==============================
+nixnet.database.lin_sched_entry
+===============================
 
 .. automodule:: nixnet.database._lin_sched_entry
     :members:

--- a/nixnet/_session/intf.py
+++ b/nixnet/_session/intf.py
@@ -139,7 +139,7 @@ class Interface(object):
         .. note:: Only CAN and LIN interfaces currently support this property.
         '''
         for ref in _props.get_session_intf_out_strm_list(self._handle):
-            yield _frame.Frame(ref)
+            yield _frame.Frame(_handle=ref)
 
     @out_strm_list.setter
     def out_strm_list(self, value):

--- a/nixnet/database/__init__.py
+++ b/nixnet/database/__init__.py
@@ -3,7 +3,26 @@ from __future__ import division
 from __future__ import print_function
 
 
+from nixnet.database._cluster import Cluster
+from nixnet.database._database_object import DatabaseObject
+from nixnet.database._ecu import Ecu
+from nixnet.database._frame import Frame
+from nixnet.database._lin_sched import LinSched
+from nixnet.database._lin_sched_entry import LinSchedEntry
+from nixnet.database._pdu import Pdu
+from nixnet.database._signal import Signal
+from nixnet.database._subframe import SubFrame
 from nixnet.database.database import Database
 
 
-__all__ = ["Database"]
+__all__ = [
+    "Cluster",
+    "Database",
+    "DatabaseObject",
+    "Ecu",
+    "Frame",
+    "LinSched",
+    "LinSchedEntry",
+    "Pdu",
+    "Signal",
+    "SubFrame"]

--- a/nixnet/database/_collection.py
+++ b/nixnet/database/_collection.py
@@ -11,6 +11,8 @@ from nixnet import _cprops
 from nixnet import _funcs
 from nixnet import constants  # NOQA: F401
 
+from nixnet.database import _database_object  # NOQA: F401
+
 
 class DbCollection(collections.Mapping):
     """Collection of database objects."""
@@ -58,7 +60,7 @@ class DbCollection(collections.Mapping):
         """
         if isinstance(index, six.string_types):
             ref = _funcs.nxdb_find_object(self._handle, self._type, index)
-            return self._factory(ref)
+            return self._factory(_handle=ref)
         else:
             raise TypeError(index)
 
@@ -93,15 +95,17 @@ class DbCollection(collections.Mapping):
             yield child.name, child
 
     def add(self, name):
-        # type: (typing.Text) -> typing.Any
+        # type: (typing.Text) -> _database_object.DatabaseObject
         """Add a new database object to the collection.
 
         Args:
             name(str): Name of the new database object.
+        Returns:
+            ``DatabaseObject``: An instance of the new database object.
         """
         ref = _funcs.nxdb_create_object(self._handle, self._type, name)
-        return self._factory(ref)
+        return self._factory(_handle=ref)
 
     def _get_children(self):
         for ref in _cprops.get_database_ref_array(self._handle, self._prop_id):
-            yield self._factory(ref)
+            yield self._factory(_handle=ref)

--- a/nixnet/database/_database_object.py
+++ b/nixnet/database/_database_object.py
@@ -1,0 +1,7 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+
+class DatabaseObject(object):
+    """Database object interface."""

--- a/nixnet/database/_ecu.py
+++ b/nixnet/database/_ecu.py
@@ -9,16 +9,23 @@ from nixnet import _props
 from nixnet import constants
 
 from nixnet.database import _cluster
+from nixnet.database import _database_object
 from nixnet.database import _dbc_attributes
 from nixnet.database import _frame
 
 
-class Ecu(object):
+class Ecu(_database_object.DatabaseObject):
     """Database ECU"""
 
-    def __init__(self, handle):
-        # type: (int) -> None
-        self._handle = handle
+    def __init__(
+            self,
+            **kwargs  # type: int
+    ):
+        # type: (...) -> None
+        if not kwargs or '_handle' not in kwargs:
+            raise TypeError()
+
+        self._handle = kwargs['_handle']
         self._dbc_attributes = None  # type: typing.Optional[_dbc_attributes.DbcAttributeCollection]
 
     def __eq__(self, other):
@@ -52,7 +59,7 @@ class Ecu(object):
         even if :any:`Database.show_invalid_from_open` is `False`.
 
         Raises:
-            XnetError: The ECU is incorrectly configured.
+            :any:`XnetError`: The ECU is incorrectly configured.
         """
         status_code = _props.get_ecu_config_status(self._handle)
         _errors.check_for_error(status_code)
@@ -66,7 +73,7 @@ class Ecu(object):
         You cannot change it afterwards.
         """
         handle = _props.get_ecu_clst_ref(self._handle)
-        return _cluster.Cluster(handle)
+        return _cluster.Cluster(_handle=handle)
 
     @property
     def comment(self):
@@ -123,7 +130,7 @@ class Ecu(object):
         All frames an ECU receives in a given cluster must be defined in the same cluster.
         """
         for ref in _props.get_ecu_rx_frm_refs(self._handle):
-            yield _frame.Frame(ref)
+            yield _frame.Frame(_handle=ref)
 
     @rx_frms.setter
     def rx_frms(self, value):
@@ -140,7 +147,7 @@ class Ecu(object):
         All frames an ECU transmits in a given cluster must be defined in the same cluster.
         """
         for ref in _props.get_ecu_tx_frm_refs(self._handle):
-            yield _frame.Frame(ref)
+            yield _frame.Frame(_handle=ref)
 
     @tx_frms.setter
     def tx_frms(self, value):

--- a/nixnet/database/_find_object.py
+++ b/nixnet/database/_find_object.py
@@ -1,0 +1,47 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import typing  # NOQA: F401
+
+from nixnet import _cconsts
+from nixnet import _errors
+from nixnet import _funcs
+from nixnet import constants
+from nixnet.database import _database_object  # NOQA: F401
+
+
+def find_object(
+        parent_handle,  # type: int
+        object_class,  # type: typing.Any
+        object_name,  # type: typing.Text
+):
+    # type: (...) -> _database_object.DatabaseObject
+    from nixnet.database._cluster import Cluster
+    from nixnet.database._ecu import Ecu
+    from nixnet.database._frame import Frame
+    from nixnet.database._lin_sched import LinSched
+    from nixnet.database._lin_sched_entry import LinSchedEntry
+    from nixnet.database._pdu import Pdu
+    from nixnet.database._signal import Signal
+    from nixnet.database._subframe import SubFrame
+
+    class_enum = {
+        Cluster: constants.ObjectClass.CLUSTER,
+        Ecu: constants.ObjectClass.ECU,
+        Frame: constants.ObjectClass.FRAME,
+        LinSched: constants.ObjectClass.LIN_SCHED,
+        LinSchedEntry: constants.ObjectClass.LIN_SCHED_ENTRY,
+        Pdu: constants.ObjectClass.PDU,
+        Signal: constants.ObjectClass.SIGNAL,
+        SubFrame: constants.ObjectClass.SUBFRAME,
+    }.get(object_class)
+
+    if class_enum is None:
+        raise ValueError("Unsupported value provided for argument object_class.", object_class)
+
+    found_handle = _funcs.nxdb_find_object(parent_handle, class_enum, object_name)
+    if found_handle == 0:
+        _errors.raise_xnet_error(_cconsts.NX_ERR_DATABASE_OBJECT_NOT_FOUND)
+
+    return object_class(_handle=found_handle)

--- a/nixnet/database/_frame.py
+++ b/nixnet/database/_frame.py
@@ -13,18 +13,27 @@ from nixnet import types
 
 from nixnet.database import _cluster
 from nixnet.database import _collection
+from nixnet.database import _database_object
 from nixnet.database import _dbc_attributes
+from nixnet.database import _find_object
 from nixnet.database import _signal
 
 
-class Frame(object):
+class Frame(_database_object.DatabaseObject):
     """Database frame"""
 
-    def __init__(self, handle):
-        # type: (int) -> None
-        from nixnet.database import _subframe
-        self._handle = handle
+    def __init__(
+            self,
+            **kwargs  # type: int
+    ):
+        # type: (...) -> None
+        if not kwargs or '_handle' not in kwargs:
+            raise TypeError()
+
+        self._handle = kwargs['_handle']
         self._dbc_attributes = None  # type: typing.Optional[_dbc_attributes.DbcAttributeCollection]
+
+        from nixnet.database import _subframe
         self._mux_static_signals = _collection.DbCollection(
             self._handle, constants.ObjectClass.SIGNAL, _cconsts.NX_PROP_FRM_MUX_STATIC_SIG_REFS, _signal.Signal)
         self._mux_subframes = _collection.DbCollection(
@@ -61,10 +70,59 @@ class Frame(object):
         even if :any:`Database.show_invalid_from_open` is `False`.
 
         Raises:
-            XnetError: The frame is incorrectly configured.
+            :any:`XnetError`: The frame is incorrectly configured.
         """
         status_code = _props.get_frame_config_status(self._handle)
         _errors.check_for_error(status_code)
+
+    def find(
+            self,
+            object_class,  # type: typing.Type[_database_object.DatabaseObject]
+            object_name,  # type: typing.Text
+    ):
+        # type: (...) -> _database_object.DatabaseObject
+        """Finds an object in the database.
+
+        This function finds a database object relative to this parent object.
+        This object may be a grandparent or great-grandparent.
+
+        If this object is a direct parent
+        (for example, :any:`Frame<_frame.Frame>` for :any:`Signal<_signal.Signal>`),
+        the ``object_name`` to search for can be short, and the search proceeds quickly.
+
+        If this object is not a direct parent
+        (for example, :any:`Database` for :any:`Signal<_signal.Signal>`),
+        the ``object_name`` to search for must be qualified such
+        that it is unique within the scope of this object.
+
+        For example, if the class of this object is :any:`Cluster`,
+        and ``object_class`` is :any:`Signal<_signal.Signal>`,
+        you can specify ``object_name`` of ``mySignal``,
+        assuming that signal name is unique to the cluster.
+        If not, you must include the :any:`Frame<_frame.Frame>` name as a prefix,
+        such as ``myFrameA.mySignal``.
+
+        NI-XNET supports the following subclasses of ``DatabaseObject`` as arguments for ``object_class``:
+
+        *   :any:`nixnet.database.Cluster<Cluster>`
+        *   :any:`nixnet.database.Frame<_frame.Frame>`
+        *   :any:`nixnet.database.Pdu<Pdu>`
+        *   :any:`nixnet.database.Signal<_signal.Signal>`
+        *   :any:`nixnet.database.SubFrame<SubFrame>`
+        *   :any:`nixnet.database.Ecu<Ecu>`
+        *   :any:`nixnet.database.LinSched<LinSched>`
+        *   :any:`nixnet.database.LinSchedEntry<LinSchedEntry>`
+
+        Args:
+            object_class(``DatabaseObject``): The class of the object to find.
+            object_name(str): The name of the object to find.
+        Returns:
+            An instance of the found object.
+        Raises:
+            ValueError: Unsupported value provided for argument ``object_class``.
+            :any:`XnetError`: The object is not found.
+        """
+        return _find_object.find_object(self._handle, object_class, object_name)
 
     @property
     def application_protocol(self):
@@ -85,7 +143,7 @@ class Frame(object):
         You cannot change the parent cluster after the frame object has been created.
         """
         handle = _props.get_frame_cluster_ref(self._handle)
-        return _cluster.Cluster(handle)
+        return _cluster.Cluster(_handle=handle)
 
     @property
     def comment(self):
@@ -290,7 +348,7 @@ class Frame(object):
         including static and dynamic signals and the multiplexer signal.
         """
         for handle in _props.get_frame_sig_refs(self._handle):
-            yield _signal.Signal(handle)
+            yield _signal.Signal(_handle=handle)
 
     @property
     def can_ext_id(self):
@@ -519,13 +577,13 @@ class Frame(object):
         A frame can contain only one data multiplexer signal.
 
         Raises:
-            XnetError: The data multiplexer signal is not defined in the frame
+            :any:`XnetError`: The data multiplexer signal is not defined in the frame
         """
         ref = _props.get_frame_mux_data_mux_sig_ref(self._handle)
         if ref == 0:
             _errors.raise_xnet_error(_cconsts.NX_ERR_SIGNAL_NOT_FOUND)
 
-        return _signal.Signal(ref)
+        return _signal.Signal(_handle=ref)
 
     @property
     def mux_static_signals(self):

--- a/nixnet/database/_lin_sched.py
+++ b/nixnet/database/_lin_sched.py
@@ -11,15 +11,24 @@ from nixnet import constants
 
 from nixnet.database import _cluster
 from nixnet.database import _collection
+from nixnet.database import _database_object
+from nixnet.database import _find_object
 
 
-class LinSched(object):
+class LinSched(_database_object.DatabaseObject):
     """Database LIN schedule"""
 
-    def __init__(self, handle):
-        # type: (int) -> None
+    def __init__(
+            self,
+            **kwargs  # type: int
+    ):
+        # type: (...) -> None
+        if not kwargs or '_handle' not in kwargs:
+            raise TypeError()
+
+        self._handle = kwargs['_handle']
+
         from nixnet.database import _lin_sched_entry
-        self._handle = handle
         self._entries = _collection.DbCollection(
             self._handle,
             constants.ObjectClass.LIN_SCHED_ENTRY,
@@ -57,10 +66,59 @@ class LinSched(object):
         even if :any:`Database.show_invalid_from_open` is `False`.
 
         Raises:
-            XnetError: The LIN schedule is incorrectly configured.
+            :any:`XnetError`: The LIN schedule is incorrectly configured.
         """
         status_code = _props.get_lin_sched_config_status(self._handle)
         _errors.check_for_error(status_code)
+
+    def find(
+            self,
+            object_class,  # type: typing.Type[_database_object.DatabaseObject]
+            object_name,  # type: typing.Text
+    ):
+        # type: (...) -> _database_object.DatabaseObject
+        """Finds an object in the database.
+
+        This function finds a database object relative to this parent object.
+        This object may be a grandparent or great-grandparent.
+
+        If this object is a direct parent
+        (for example, :any:`Frame<_frame.Frame>` for :any:`Signal<_signal.Signal>`),
+        the ``object_name`` to search for can be short, and the search proceeds quickly.
+
+        If this object is not a direct parent
+        (for example, :any:`Database` for :any:`Signal<_signal.Signal>`),
+        the ``object_name`` to search for must be qualified such
+        that it is unique within the scope of this object.
+
+        For example, if the class of this object is :any:`Cluster`,
+        and ``object_class`` is :any:`Signal<_signal.Signal>`,
+        you can specify ``object_name`` of ``mySignal``,
+        assuming that signal name is unique to the cluster.
+        If not, you must include the :any:`Frame<_frame.Frame>` name as a prefix,
+        such as ``myFrameA.mySignal``.
+
+        NI-XNET supports the following subclasses of ``DatabaseObject`` as arguments for ``object_class``:
+
+        *   :any:`nixnet.database.Cluster<Cluster>`
+        *   :any:`nixnet.database.Frame<_frame.Frame>`
+        *   :any:`nixnet.database.Pdu<Pdu>`
+        *   :any:`nixnet.database.Signal<_signal.Signal>`
+        *   :any:`nixnet.database.SubFrame<SubFrame>`
+        *   :any:`nixnet.database.Ecu<Ecu>`
+        *   :any:`nixnet.database.LinSched<LinSched>`
+        *   :any:`nixnet.database.LinSchedEntry<LinSchedEntry>`
+
+        Args:
+            object_class(``DatabaseObject``): The class of the object to find.
+            object_name(str): The name of the object to find.
+        Returns:
+            An instance of the found object.
+        Raises:
+            ValueError: Unsupported value provided for argument ``object_class``.
+            :any:`XnetError`: The object is not found.
+        """
+        return _find_object.find_object(self._handle, object_class, object_name)
 
     @property
     def clst(self):
@@ -70,7 +128,7 @@ class LinSched(object):
         You cannot change the parent cluster after creating the schedule object.
         """
         handle = _props.get_lin_sched_clst_ref(self._handle)
-        return _cluster.Cluster(handle)
+        return _cluster.Cluster(_handle=handle)
 
     @property
     def comment(self):

--- a/nixnet/database/_lin_sched_entry.py
+++ b/nixnet/database/_lin_sched_entry.py
@@ -9,16 +9,23 @@ from nixnet import _errors
 from nixnet import _props
 from nixnet import constants
 
+from nixnet.database import _database_object
 from nixnet.database import _frame
 from nixnet.database import _lin_sched
 
 
-class LinSchedEntry(object):
+class LinSchedEntry(_database_object.DatabaseObject):
     """Database LIN schedule entry"""
 
-    def __init__(self, handle):
-        # type: (int) -> None
-        self._handle = handle
+    def __init__(
+            self,
+            **kwargs  # type: int
+    ):
+        # type: (...) -> None
+        if not kwargs or '_handle' not in kwargs:
+            raise TypeError()
+
+        self._handle = kwargs['_handle']
 
     def __eq__(self, other):
         if isinstance(other, self.__class__):
@@ -49,13 +56,13 @@ class LinSchedEntry(object):
         the master must switch to the collision resolving schedule to transfer the unconditional frames successfully.
 
         Raises:
-            XnetError: The property requires that :any:`LinSchedEntry.type` be set to ``EVENT_TRIGGERED``.
+            :any:`XnetError`: The property requires that :any:`LinSchedEntry.type` be set to ``EVENT_TRIGGERED``.
         """
         handle = _props.get_lin_sched_entry_collision_res_sched(self._handle)
         if handle == 0:
             _errors.raise_xnet_error(_cconsts.NX_ERR_DATABASE_OBJECT_NOT_FOUND)
 
-        return _lin_sched.LinSched(handle)
+        return _lin_sched.LinSched(_handle=handle)
 
     @collision_res_sched.setter
     def collision_res_sched(self, value):
@@ -114,7 +121,7 @@ class LinSchedEntry(object):
         this property uses the :any:`LinSchedEntry.collision_res_sched` to process the frames.
         """
         for ref in _props.get_lin_sched_entry_frames(self._handle):
-            yield _frame.Frame(ref)
+            yield _frame.Frame(_handle=ref)
 
     @frames.setter
     def frames(self, value):
@@ -166,7 +173,7 @@ class LinSchedEntry(object):
         You cannot change it afterwards.
         """
         handle = _props.get_lin_sched_entry_sched(self._handle)
-        lin_sched = _lin_sched.LinSched(handle)
+        lin_sched = _lin_sched.LinSched(_handle=handle)
         return lin_sched
 
     @property

--- a/nixnet/database/_pdu.py
+++ b/nixnet/database/_pdu.py
@@ -11,18 +11,27 @@ from nixnet import constants
 
 from nixnet.database import _cluster
 from nixnet.database import _collection
+from nixnet.database import _database_object
+from nixnet.database import _find_object
 from nixnet.database import _frame
 from nixnet.database import _signal
 
 
-class Pdu(object):
+class Pdu(_database_object.DatabaseObject):
     """Database PDU"""
 
-    def __init__(self, handle):
-        # type: (int) -> None
+    def __init__(
+            self,
+            **kwargs  # type: int
+    ):
+        # type: (...) -> None
+        if not kwargs or '_handle' not in kwargs:
+            raise TypeError()
+
+        self._handle = kwargs['_handle']
+
         from nixnet.database import _signal
         from nixnet.database import _subframe
-        self._handle = handle
         self._signals = _collection.DbCollection(
             self._handle, constants.ObjectClass.SIGNAL, _cconsts.NX_PROP_PDU_SIG_REFS, _signal.Signal)
         self._mux_subframes = _collection.DbCollection(
@@ -59,10 +68,59 @@ class Pdu(object):
         even if :any:`Database.show_invalid_from_open` is `False`.
 
         Raises:
-            XnetError: The PDU is incorrectly configured.
+            :any:`XnetError`: The PDU is incorrectly configured.
         """
         status_code = _props.get_pdu_config_status(self._handle)
         _errors.check_for_error(status_code)
+
+    def find(
+            self,
+            object_class,  # type: typing.Type[_database_object.DatabaseObject]
+            object_name,  # type: typing.Text
+    ):
+        # type: (...) -> _database_object.DatabaseObject
+        """Finds an object in the database.
+
+        This function finds a database object relative to this parent object.
+        This object may be a grandparent or great-grandparent.
+
+        If this object is a direct parent
+        (for example, :any:`Frame<_frame.Frame>` for :any:`Signal<_signal.Signal>`),
+        the ``object_name`` to search for can be short, and the search proceeds quickly.
+
+        If this object is not a direct parent
+        (for example, :any:`Database` for :any:`Signal<_signal.Signal>`),
+        the ``object_name`` to search for must be qualified such
+        that it is unique within the scope of this object.
+
+        For example, if the class of this object is :any:`Cluster`,
+        and ``object_class`` is :any:`Signal<_signal.Signal>`,
+        you can specify ``object_name`` of ``mySignal``,
+        assuming that signal name is unique to the cluster.
+        If not, you must include the :any:`Frame<_frame.Frame>` name as a prefix,
+        such as ``myFrameA.mySignal``.
+
+        NI-XNET supports the following subclasses of ``DatabaseObject`` as arguments for ``object_class``:
+
+        *   :any:`nixnet.database.Cluster<Cluster>`
+        *   :any:`nixnet.database.Frame<_frame.Frame>`
+        *   :any:`nixnet.database.Pdu<Pdu>`
+        *   :any:`nixnet.database.Signal<_signal.Signal>`
+        *   :any:`nixnet.database.SubFrame<SubFrame>`
+        *   :any:`nixnet.database.Ecu<Ecu>`
+        *   :any:`nixnet.database.LinSched<LinSched>`
+        *   :any:`nixnet.database.LinSchedEntry<LinSchedEntry>`
+
+        Args:
+            object_class(``DatabaseObject``): The class of the object to find.
+            object_name(str): The name of the object to find.
+        Returns:
+            An instance of the found object.
+        Raises:
+            ValueError: Unsupported value provided for argument ``object_class``.
+            :any:`XnetError`: The object is not found.
+        """
+        return _find_object.find_object(self._handle, object_class, object_name)
 
     @property
     def cluster(self):
@@ -72,7 +130,7 @@ class Pdu(object):
         You cannot change the parent cluster after creating the PDU object.
         """
         handle = _props.get_pdu_cluster_ref(self._handle)
-        return _cluster.Cluster(handle)
+        return _cluster.Cluster(_handle=handle)
 
     @property
     def default_payload(self):
@@ -108,7 +166,7 @@ class Pdu(object):
         You can map one PDU to multiple frames.
         """
         for handle in _props.get_pdu_frm_refs(self._handle):
-            yield _frame.Frame(handle)
+            yield _frame.Frame(_handle=handle)
 
     @property
     def name(self):
@@ -186,7 +244,7 @@ class Pdu(object):
         """:any:`Signal<_signal.Signal>`: Data multiplexer signal in the PDU.
 
         This property returns the reference to the data multiplexer signal.
-        If data multiplexer is not defined in the PDU, the property raises an XnetError exception.
+        If data multiplexer is not defined in the PDU, the property raises an :any:`XnetError` exception.
         Use the :any:`Pdu.mux_is_muxed` property to determine whether the PDU contains a multiplexer signal.
 
         You can create a data multiplexer signal by creating a signal
@@ -195,13 +253,13 @@ class Pdu(object):
         A PDU can contain only one data multiplexer signal.
 
         Raises:
-            XnetError: The data multiplexer is not defined in the PDU.
+            :any:`XnetError`: The data multiplexer is not defined in the PDU.
         """
         handle = _props.get_pdu_mux_data_mux_sig_ref(self._handle)
         if handle == 0:
             _errors.raise_xnet_error(_cconsts.NX_ERR_SIGNAL_NOT_FOUND)
 
-        return _signal.Signal(handle)
+        return _signal.Signal(_handle=handle)
 
     @property
     def mux_static_sigs(self):
@@ -221,7 +279,7 @@ class Pdu(object):
         this property returns the same list as the :any:`Pdu.signals` property.
         """
         for handle in _props.get_pdu_mux_static_sig_refs(self._handle):
-            yield _signal.Signal(handle)
+            yield _signal.Signal(_handle=handle)
 
     @property
     def mux_subframes(self):


### PR DESCRIPTION
Fixes #239

The following parent database objects now have a find method:
- database
- cluster
- lin schedule
- pdu
- frame
- subframe

All database object are now subclasses of
DatabaseObject, which is used as an interface.
Database objects are now exposed through the
nixnet.database namespace, and their constructors
now take kwargs to signal to users that these
objects should not be instantiated by users.

I tested on the shipping example database "NIXNET_example"
to ensure I can indeed find children and grandchildren,
and that sane errors are thrown when the object name
not found or the object class is wrong.
Unit tests will be added in #238.

- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nixnet-python/blob/master/CONTRIBUTING.rst).
- [ ] ~~New tests have been created for any new features or regression tests for bugfixes.~~
- [x] `tox` successfully runs, including unit tests and style checks (see [CONTRIBUTING.md](https://github.com/ni/nixnet-python/blob/master/CONTRIBUTING.rst)).
