### PR TITLE
fix(API): Fix bug for state size in nx_read_state

### DIFF
--- a/nixnet/_funcs.py
+++ b/nixnet/_funcs.py
@@ -141,12 +141,13 @@ def nx_read_signal_single_point(
 def nx_read_state(
     session_ref,  # type: int
     state_id,  # type: _enums.ReadState
+    state_size,  # type: int
     state_value_ctypes_ptr,  # type: typing.Any
 ):
     # type: (...) -> typing.Tuple[typing.Any, int]
     session_ref_ctypes = _ctypedefs.nxSessionRef_t(session_ref)
     state_id_ctypes = _ctypedefs.u32(state_id.value)
-    state_size_ctypes = _ctypedefs.u32(ctypes.sizeof(state_value_ctypes_ptr))
+    state_size_ctypes = _ctypedefs.u32(state_size)
     fault_ctypes = _ctypedefs.nxStatus_t()
     result = _cfuncs.lib.nx_read_state(
         session_ref_ctypes,

--- a/nixnet/_session/base.py
+++ b/nixnet/_session/base.py
@@ -377,9 +377,11 @@ class SessionBase(object):
         # type: () -> int
         """int: Current interface time."""
         state_value_ctypes = _ctypedefs.nxTimestamp_t()
+        state_size = ctypes.sizeof(state_value_ctypes)
         _funcs.nx_read_state(
             self._handle,
             constants.ReadState.TIME_CURRENT,
+            state_size,
             ctypes.pointer(state_value_ctypes))
         time = state_value_ctypes.value
         return time
@@ -389,9 +391,11 @@ class SessionBase(object):
         # type: () -> int
         """int: Time the interface was started."""
         state_value_ctypes = _ctypedefs.nxTimestamp_t()
+        state_size = ctypes.sizeof(state_value_ctypes)
         _funcs.nx_read_state(
             self._handle,
             constants.ReadState.TIME_START,
+            state_size,
             ctypes.pointer(state_value_ctypes))
         time = state_value_ctypes.value
         if time == 0:
@@ -408,9 +412,11 @@ class SessionBase(object):
         must undergo a communication startup procedure.
         """
         state_value_ctypes = _ctypedefs.nxTimestamp_t()
+        state_size = ctypes.sizeof(state_value_ctypes)
         _funcs.nx_read_state(
             self._handle,
             constants.ReadState.TIME_COMMUNICATING,
+            state_size,
             ctypes.pointer(state_value_ctypes))
         time = state_value_ctypes.value
         if time == 0:
@@ -423,9 +429,11 @@ class SessionBase(object):
         # type: () -> constants.SessionInfoState
         """:any:`nixnet._enums.SessionInfoState`: Session running state."""
         state_value_ctypes = _ctypedefs.u32()
+        state_size = ctypes.sizeof(state_value_ctypes)
         _funcs.nx_read_state(
             self._handle,
             constants.ReadState.SESSION_INFO,
+            state_size,
             ctypes.pointer(state_value_ctypes))
         state = state_value_ctypes.value
         return constants.SessionInfoState(state)
@@ -435,9 +443,11 @@ class SessionBase(object):
         # type: () -> types.CanComm
         """:any:`nixnet.types.CanComm`: CAN Communication state"""
         state_value_ctypes = _ctypedefs.u32()
+        state_size = ctypes.sizeof(state_value_ctypes)
         _funcs.nx_read_state(
             self._handle,
             constants.ReadState.CAN_COMM,
+            state_size,
             ctypes.pointer(state_value_ctypes))
         bitfield = state_value_ctypes.value
         return _utils.parse_can_comm_bitfield(bitfield)
@@ -447,9 +457,11 @@ class SessionBase(object):
         # type: () -> types.LinComm
         """:any:`nixnet.types.LinComm`: LIN Communication state"""
         state_value_ctypes = (_ctypedefs.u32 * 2)()  # type: ignore
+        state_size = ctypes.sizeof(state_value_ctypes)
         _funcs.nx_read_state(
             self._handle,
             constants.ReadState.LIN_COMM,
+            state_size,
             ctypes.pointer(state_value_ctypes))
         first = state_value_ctypes[0].value
         second = state_value_ctypes[1].value
@@ -468,9 +480,11 @@ class SessionBase(object):
         of checking the communication state.
         """
         state_value_ctypes = _ctypedefs.u32()
+        state_size = ctypes.sizeof(state_value_ctypes)
         fault = _funcs.nx_read_state(
             self._handle,
             constants.ReadState.SESSION_INFO,
+            state_size,
             ctypes.pointer(state_value_ctypes))
         _errors.check_for_error(fault)
 


### PR DESCRIPTION
Fixes #247

nx_read_state should receive the size of state
value, not the size of the state value pointer.

- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nixnet-python/blob/master/CONTRIBUTING.rst).
- [x] New tests have been created for any new features or regression tests for bugfixes.
- [x] `tox` successfully runs, including unit tests and style checks (see [CONTRIBUTING.md](https://github.com/ni/nixnet-python/blob/master/CONTRIBUTING.rst)).

### What testing has been done?

I ran unit and integration tests for both CAN and LIN against both 32 and 64 bit python for both python 2.7 and 3.6.
