### PR TITLE
test: Show python version and architecture (bitness) in tox tests

### DIFF
--- a/tox-integration.ini
+++ b/tox-integration.ini
@@ -8,10 +8,15 @@ skip_missing_interpreters=True
 
 [testenv]
 description = Run tests
+
 commands =
+    test: python --version
+    test: python -c "import platform; print(platform.architecture())"
     test: pytest --junit-xml=junit/{envname}.xml --junit-prefix={envname} {posargs: --can-in-interface {env:CAN_FIXTURE_IN_INTERFACE:None} --can-out-interface {env:CAN_FIXTURE_OUT_INTERFACE:None} --lin-in-interface {env:LIN_FIXTURE_IN_INTERFACE:None} --lin-out-interface {env:LIN_FIXTURE_OUT_INTERFACE:None}}
+
 deps =
     -rrequirements_test.txt
+
 passenv =
     CAN_FIXTURE_IN_INTERFACE
     CAN_FIXTURE_OUT_INTERFACE

--- a/tox.ini
+++ b/tox.ini
@@ -9,32 +9,45 @@ skip_missing_interpreters=True
 [testenv]
 description = Run tests
 commands =
+    test: python --version
+    test: python -c "import platform; print(platform.architecture())"
     test: pytest --junit-xml=junit/{envname}.xml --junit-prefix={envname} {posargs: -m "not integration"}
 deps =
     -rrequirements_test.txt
 
 [testenv:flake8]
 description = Run static analysis
-commands = flake8 {posargs}
+commands =
+    python --version
+    python -c "import platform; print(platform.architecture())"
+    flake8 {posargs}
 deps =
     -rrequirements_test.txt
 
 [testenv:mypy]
 description = Run type analysis
-commands = mypy nixnet nixnet_examples tests {posargs}
+commands =
+    python --version
+    python -c "import platform; print(platform.architecture())"
+    mypy nixnet nixnet_examples tests {posargs}
 deps =
     -rrequirements_mypy.txt
 
 [testenv:docs]
 description = Generate documentation
 changedir = docs
-commands = sphinx-build -W -b html -d {envtmpdir}/doctrees . {envtmpdir}/html {posargs}
+commands =
+    python --version
+    python -c "import platform; print(platform.architecture())"
+    sphinx-build -W -b html -d {envtmpdir}/doctrees . {envtmpdir}/html {posargs}
 deps =
     -rrequirements_test.txt
 
 [testenv:pkg]
 description = Verify the package
 commands =
+    python --version
+    python -c "import platform; print(platform.architecture())"
     python setup.py check -m -r -s
     check-manifest --ignore tox*.ini,tests,*.in,.*,.*/*,CONTRIBUTING.rst,MAINTAINING.rst,docs,docs/*,Jenkinsfile
 deps =


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nixnet-python/blob/master/CONTRIBUTING.rst).
- [x] New tests have been created for any new features or regression tests for bugfixes.
- [x] `tox` successfully runs, including unit tests and style checks (see [CONTRIBUTING.md](https://github.com/ni/nixnet-python/blob/master/CONTRIBUTING.rst)).