### PR TITLE
fix(examples): payload print issue

### DIFF
--- a/nixnet_examples/can_frame_queued_io.py
+++ b/nixnet_examples/can_frame_queued_io.py
@@ -63,7 +63,8 @@ def main():
 
                 frame.payload = payload
                 output_session.frames.write([frame])
-                print('Sent frame with ID {} payload: {}'.format(id, payload))
+                print('Sent frame with ID: {} payload: {}'.format(frame.identifier,
+                                                                  list(frame.payload)))
 
                 # Wait 1 s and then read the received values.
                 # They should be the same as the ones sent.
@@ -72,8 +73,8 @@ def main():
                 count = 1
                 frames = input_session.frames.read(count)
                 for frame in frames:
-                    print('Received frame: {}'.format(frame))
-                    print('    payload={}'.format(list(six.iterbytes(frame.payload))))
+                    print('Received frame with ID: {} payload: {}'.format(frame.identifier,
+                                                                          list(six.iterbytes(frame.payload))))
 
                 i += 1
                 if max(payload) + i > 0xFF:

--- a/nixnet_examples/can_frame_stream_io.py
+++ b/nixnet_examples/can_frame_stream_io.py
@@ -55,7 +55,8 @@ def main():
 
                 frame.payload = payload
                 output_session.frames.write([frame])
-                print('Sent frame with ID {} payload: {}'.format(id, payload))
+                print('Sent frame with ID: {} payload: {}'.format(frame.identifier,
+                                                                  list(frame.payload)))
 
                 # Wait 1 s and then read the received values.
                 # They should be the same as the ones sent.
@@ -64,8 +65,8 @@ def main():
                 count = 1
                 frames = input_session.frames.read(count)
                 for frame in frames:
-                    print('Received frame: {}'.format(frame))
-                    print('    payload={}'.format(list(six.iterbytes(frame.payload))))
+                    print('Received frame with ID: {} payload: {}'.format(frame.identifier,
+                                                                          list(six.iterbytes(frame.payload))))
 
                 i += 1
                 if max(payload) + i > 0xFF:

--- a/nixnet_examples/lin_frame_stream_io.py
+++ b/nixnet_examples/lin_frame_stream_io.py
@@ -58,7 +58,8 @@ def main():
 
                 frame.payload = payload
                 output_session.frames.write([frame])
-                print('Sent frame with ID {} payload: {}'.format(id, payload))
+                print('Sent frame with ID: {} payload: {}'.format(frame.identifier,
+                                                                  list(frame.payload)))
 
                 # Wait 1 s and then read the received values.
                 # They should be the same as the ones sent.
@@ -67,8 +68,8 @@ def main():
                 count = 1
                 frames = input_session.frames.read(count)
                 for frame in frames:
-                    print('Received frame: {}'.format(frame))
-                    print('    payload={}'.format(list(six.iterbytes(frame.payload))))
+                    print('Received frame with ID: {} payload: {}'.format(frame.identifier,
+                                                                          list(six.iterbytes(frame.payload))))
 
                 i += 1
                 if max(payload) + i > 0xFF:

--- a/nixnet_examples/programmatic_database_usage.py
+++ b/nixnet_examples/programmatic_database_usage.py
@@ -58,7 +58,7 @@ def main():
 
             frame.payload = payload
             output_session.frames.write([frame])
-            print('Sent frame with ID %s payload: %s' % (id, payload))
+            print('Sent frame with ID: {} payload: {}'.format(frame.identifier, list(frame.payload)))
             i += 1
 
     with system.System() as my_system:


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nixnet-python/blob/master/CONTRIBUTING.rst).
~~- []New tests have been created for any new features or regression tests for bugfixes.~~
- [x] `tox` successfully runs, including unit tests and style checks (see [CONTRIBUTING.md](https://github.com/ni/nixnet-python/blob/master/CONTRIBUTING.rst)).

in python 2.7.latest, payloads were getting printed in non-ascii characters/symbols

Fixing payload print issue for python27 and improving it for python34.

Making sent and receive print lines consistent so we can compare them
easily.