### PR TITLE
fix(API): CAN frame ID's are 11 bits

### DIFF
--- a/nixnet/types.py
+++ b/nixnet/types.py
@@ -180,7 +180,7 @@ class CanIdentifier(object):
         extended(bool): If the identifier is extended
     """
 
-    _FRAME_ID_MASK = 0x000003FF
+    _FRAME_ID_MASK = 0x000007FF
     _EXTENDED_FRAME_ID_MASK = 0x1FFFFFFF
 
     def __init__(self, identifier, extended=False):


### PR DESCRIPTION
Fixes #266

CanIdentifier's _FRAME_ID_MASK should allow 11-bit IDs.

- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nixnet-python/blob/master/CONTRIBUTING.rst).
- [x] New tests have been created for any new features or regression tests for bugfixes.
- [x] `tox` successfully runs, including unit tests and style checks (see [CONTRIBUTING.md](https://github.com/ni/nixnet-python/blob/master/CONTRIBUTING.rst)).