### PR TITLE
fix(API): Fix bug in DbCollection.__repr__

### DIFF
--- a/nixnet/database/_collection.py
+++ b/nixnet/database/_collection.py
@@ -25,7 +25,7 @@ class DbCollection(collections.Mapping):
         self._factory = factory
 
     def __repr__(self):
-        return '{}(handle={0}, db_type={1})'.format(type(self).__name__, self._handle, self._type)
+        return '{}(handle={}, db_type={})'.format(type(self).__name__, self._handle, self._type)
 
     def __eq__(self, other):
         if isinstance(other, self.__class__):

--- a/tests/test_database_collection.py
+++ b/tests/test_database_collection.py
@@ -1,0 +1,43 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import pytest  # type: ignore
+
+from nixnet import database
+from nixnet import errors
+
+from nixnet.database import _collection  # NOQA: F401
+
+
+@pytest.mark.integration
+def test_database_collection_container():
+    test_cluster_name = '__cluster__name__for__testing__'
+    with database.Database('NIXNET_example') as db:
+        collection_1 = db.clusters  # type: _collection.DbCollection
+        collection_2 = db.clusters  # type: _collection.DbCollection
+        collection_3 = db.clusters['CAN_Cluster'].ecus  # type: _collection.DbCollection
+
+        # test dunders
+        assert collection_1 == collection_2
+        assert collection_1 != collection_3
+        assert len({collection_1, collection_2, collection_3}) == 2  # testing `__hash__`
+        print(repr(collection_1))
+        for key in collection_1:
+            print(collection_1[key])
+        with pytest.raises(errors.XnetError):
+            print(collection_1[test_cluster_name])
+        with pytest.raises(TypeError):
+            print(collection_1[5])
+
+        # test '__del__' after using the add function
+        cluster = db.clusters.add(test_cluster_name)
+        assert (cluster == db.clusters[test_cluster_name])
+        del db.clusters[test_cluster_name]
+        with pytest.raises(errors.XnetError):
+            print(db.clusters[test_cluster_name])
+
+        # test container
+        assert len(list(collection_1.keys())) > 0
+        assert len(list(collection_1.values())) > 0
+        assert len(list(collection_1.items())) > 0

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -75,7 +75,4 @@ def test_driver_call():
         _errors.check_for_error(_enums.Err.SELF_TEST_ERROR1.value)
     assert excinfo.value.error_code == _enums.Err.SELF_TEST_ERROR1.value
     assert excinfo.value.error_type == _enums.Err.SELF_TEST_ERROR1
-    assert excinfo.value.args == (
-        'NI-XNET:  (Hex 0xBFF63002) Board self test failed(code 2). '
-        'Solution: try reinstalling the driver or switching the slot(s) of the board(s). '
-        'If the error persists,contact National Instruments.', )
+    assert '(Hex 0xBFF63002)' in excinfo.value.args[0]


### PR DESCRIPTION
Fixes #264

- Add an integration test for DbCollection class.
- Fix test_driver_call to be less dependent on driver string.

- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nixnet-python/blob/master/CONTRIBUTING.rst).
- [x] New tests have been created for any new features or regression tests for bugfixes.
- [x] `tox` successfully runs, including unit tests and style checks (see [CONTRIBUTING.md](https://github.com/ni/nixnet-python/blob/master/CONTRIBUTING.rst)).