### PR TITLE
Replaced backslash to ensure that the example can run on Linux

### DIFF
--- a/nixnet_examples/programmatic_database_usage.py
+++ b/nixnet_examples/programmatic_database_usage.py
@@ -15,7 +15,7 @@ from nixnet import types
 def main():
     with system.System() as my_system:
         database_alias = 'custom_database'
-        database_filepath = os.path.join(os.path.dirname(__file__), 'databases\custom_database.dbc')
+        database_filepath = os.path.join(os.path.dirname(__file__), 'databases', 'custom_database.dbc')
         default_baud_rate = 500000
         my_system.databases.add_alias(database_alias, database_filepath, default_baud_rate)
 


### PR DESCRIPTION
While this example functions on Windows, the backslash in the DBC file path prevents it from functioning properly on Linux.
I replaced the backslash with proper path construction that will work for all platforms.

- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nixnet-python/blob/main/CONTRIBUTING.rst).
- [ ] New tests have been created for any new features or regression tests for bugfixes.
- [ ] `tox` successfully runs, including unit tests and style checks (see [CONTRIBUTING.md](https://github.com/ni/nixnet-python/blob/main/CONTRIBUTING.rst)).

### What does this Pull Request accomplish?

Replaced backslash to ensure that the example can run on Linux

### Why should this Pull Request be merged?

To allow this example to run on Linux.

### What testing has been done?

Manual testing of the example to ensure that it forms the path properly.
