### PR TITLE
Database strings encoded as utf-8 instead of ascii

### DIFF
--- a/nixnet/_cprops.py
+++ b/nixnet/_cprops.py
@@ -573,7 +573,7 @@ def get_database_string(ref, prop_id):
 
 def set_database_string(ref, prop_id, value):
     # type: (int, int, typing.Text) -> None
-    value_bytes = value.encode("ansi")
+    value_bytes = value.encode("utf-8")
     value_size = len(value_bytes) * _ctypedefs.char.BYTES
 
     ref_ctypes = _ctypedefs.nxDatabaseRef_t(ref)

--- a/nixnet/_cprops.py
+++ b/nixnet/_cprops.py
@@ -568,12 +568,12 @@ def get_database_string(ref, prop_id):
         prop_size_ctypes,
         value_ctypes)
     _errors.check_for_error(result.value)
-    return value_ctypes.value.decode("ascii")
+    return "".join(chr(x) for x in value_ctypes.value)
 
 
 def set_database_string(ref, prop_id, value):
     # type: (int, int, typing.Text) -> None
-    value_bytes = value.encode("ascii")
+    value_bytes = value.encode("ansi")
     value_size = len(value_bytes) * _ctypedefs.char.BYTES
 
     ref_ctypes = _ctypedefs.nxDatabaseRef_t(ref)


### PR DESCRIPTION
characters like ä, ö, ü... are now supported in database strings

- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nixnet-python/blob/main/CONTRIBUTING.rst).
- [ ] New tests have been created for any new features or regression tests for bugfixes.
- [x] `tox` successfully runs, including unit tests and style checks (see [CONTRIBUTING.md](https://github.com/ni/nixnet-python/blob/main/CONTRIBUTING.rst)).

### What does this Pull Request accomplish?
Support for extended characters (like ä, ö, ü...) in database strings.

### Why should this Pull Request be merged?
Those characters are supported by the NI-XNET-DatabaseEditor so it would be more consistent.

### What testing has been done?
I ran tox and have been using this modification for months and didn't notice any side effect.
