### PR TITLE
Fix python 3.10 errors (deprecated collections)

### DIFF
--- a/nixnet/_session/collection.py
+++ b/nixnet/_session/collection.py
@@ -3,7 +3,10 @@ from __future__ import division
 from __future__ import print_function
 
 import abc
-import collections
+try:
+    from collections.abc import Sequence  # python 3.3+
+except ImportError:
+    from collections import Sequence  # python 2.7
 import typing  # NOQA: F401
 
 import six
@@ -12,7 +15,7 @@ from nixnet import _props
 
 
 @six.add_metaclass(abc.ABCMeta)
-class Collection(collections.Sequence):
+class Collection(Sequence):
     """Collection of items in a session."""
 
     def __init__(self, handle):

--- a/nixnet/_utils.py
+++ b/nixnet/_utils.py
@@ -2,7 +2,10 @@
 from __future__ import division
 from __future__ import print_function
 
-import collections
+try:
+    from collections.abc import Iterable # python 3.3+
+except ImportError:
+    from collections import Iterable  # python 2.7
 import typing  # NOQA: F401
 
 import six
@@ -30,7 +33,7 @@ def flatten_items(list):
         if ',' in list:
             _errors.raise_xnet_error(_cconsts.NX_ERR_INVALID_PROPERTY_VALUE)
         flattened = list
-    elif isinstance(list, collections.Iterable):
+    elif isinstance(list, Iterable):
         flattened = ",".join(list)
     elif list is None:
         # For FRAME_IN_STREAM / FRAME_OUT_STREAM

--- a/nixnet/database/_collection.py
+++ b/nixnet/database/_collection.py
@@ -2,7 +2,10 @@
 from __future__ import division
 from __future__ import print_function
 
-import collections
+try:
+    from collections.abc import Mapping  # python 3.3+
+except ImportError:
+    from collections import Mapping  # python 2.7
 import typing  # NOQA: F401
 
 import six
@@ -14,7 +17,7 @@ from nixnet import constants  # NOQA: F401
 from nixnet.database import _database_object  # NOQA: F401
 
 
-class DbCollection(collections.Mapping):
+class DbCollection(Mapping):
     """Collection of database objects."""
 
     def __init__(self, handle, db_type, prop_id, factory):

--- a/nixnet/database/_dbc_attributes.py
+++ b/nixnet/database/_dbc_attributes.py
@@ -2,7 +2,10 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import collections
+try:
+    from collections.abc import Mapping  # python 3.3+
+except ImportError:
+    from collections import Mapping  # python 2.7
 import six
 import typing  # NOQA: F401
 
@@ -10,7 +13,7 @@ from nixnet import _funcs
 from nixnet import constants
 
 
-class DbcAttributeCollection(collections.Mapping):
+class DbcAttributeCollection(Mapping):
     """Collection for accessing DBC attributes."""
 
     def __init__(self, handle):

--- a/nixnet/database/_dbc_signal_value_table.py
+++ b/nixnet/database/_dbc_signal_value_table.py
@@ -2,7 +2,10 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import collections
+try:
+    from collections.abc import Mapping  # python 3.3+
+except ImportError:
+    from collections import Mapping  # python 2.7
 import six
 import typing  # NOQA: F401
 
@@ -10,7 +13,7 @@ from nixnet import _funcs
 from nixnet import constants
 
 
-class DbcSignalValueTable(collections.Mapping):
+class DbcSignalValueTable(Mapping):
     """Collection for accessing a DBC signal value table."""
 
     def __init__(self, handle):

--- a/nixnet/system/_collection.py
+++ b/nixnet/system/_collection.py
@@ -2,13 +2,16 @@
 from __future__ import division
 from __future__ import print_function
 
-import collections
+try:
+    from collections.abc import Iterable, Sized  # python 3.3+
+except ImportError:
+    from collections import Iterable, Sized  # python 2.7
 import typing  # NOQA: F401
 
 from nixnet import _cprops
 
 
-class SystemCollection(collections.Iterable, collections.Sized):
+class SystemCollection(Iterable, Sized):
     """Collection of System related objects."""
 
     def __init__(self, handle, prop_id, factory):

--- a/nixnet/system/_databases.py
+++ b/nixnet/system/_databases.py
@@ -2,7 +2,10 @@
 from __future__ import division
 from __future__ import print_function
 
-import collections
+try:
+    from collections.abc import Mapping  # python 3.3+
+except ImportError:
+    from collections import Mapping  # python 2.7
 import typing  # NOQA: F401
 
 import six
@@ -10,7 +13,7 @@ import six
 from nixnet import _funcs
 
 
-class AliasCollection(collections.Mapping):
+class AliasCollection(Mapping):
     """Alias aliases."""
 
     def __init__(self, handle):


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nixnet-python/blob/main/CONTRIBUTING.rst).
- [ ] New tests have been created for any new features or regression tests for bugfixes.
- [ ] `tox` successfully runs, including unit tests and style checks (see [CONTRIBUTING.md](https://github.com/ni/nixnet-python/blob/main/CONTRIBUTING.rst)).

### What does this Pull Request accomplish?

I replaced deprecated use cases of "collections" with up to date "collections.abc" for python 3.3+ leaving backwards compatibility. This makes it possible to use nixnet with python 3.10 where those deprecated use cases were no longer supported.

### Why should this Pull Request be merged?

Support for 3.10 enables enjoying bug-fixes like:
[bpo-41299](https://bugs.python.org/issue?@action=redirect&bpo=41299): Fix 16ms jitter when using timeouts in [threading](https://docs.python.org/3/library/threading.html#module-threading), such as with [threading.Lock.acquire()](https://docs.python.org/3/library/threading.html#threading.Lock.acquire) or [threading.Condition.wait()](https://docs.python.org/3/library/threading.html#threading.Condition.wait).

### What testing has been done?

I successfully used the changes to test a CAN bus with python 3.10.