### PR TITLE
Fix `tox -e docs` errors with Sphinx 7.1.2

### DIFF
--- a/docs/api_reference/types.rst
+++ b/docs/api_reference/types.rst
@@ -4,3 +4,4 @@ nixnet.types
 .. automodule:: nixnet.types
     :members:
     :show-inheritance:
+    :exclude-members: type

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -94,7 +94,7 @@ release = get_version()
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = 'en'
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nixnet-python/blob/main/CONTRIBUTING.rst).
~- [ ] New tests have been created for any new features or regression tests for bugfixes.~
~- [ ] `tox` successfully runs, including unit tests and style checks (see [CONTRIBUTING.md](https://github.com/ni/nixnet-python/blob/main/CONTRIBUTING.rst)).~

### What does this Pull Request accomplish?

This PR is to fix the docs-related errors that will arise when the Sphinx dependency is upgraded to v7.1.2 for newer Python versions.

### Why should this Pull Request be merged?

This PR is part of a series of PRs to prepare for supporting newer Python versions.

### What testing has been done?

Locally run `tox` successfully with Python 3.7.9 (there are some existing issues with running tox with Python 3.4 or older and Python 3.8 or newer (requires upgraded dependencies), except flake8 which fails due to some existing issues which will be fixed in a subsequent PR.