### PR TITLE
Fix flake8 warnings

### DIFF
--- a/nixnet/_frames.py
+++ b/nixnet/_frames.py
@@ -10,7 +10,7 @@ from nixnet import constants
 from nixnet import types
 
 
-nxFrameFixed_t = struct.Struct('QIBBBB8s')  # NOQA: N801
+nxFrameFixed_t = struct.Struct('QIBBBB8s')  # NOQA: N801, N816
 assert nxFrameFixed_t.size == 24, 'Incorrectly specified frame.'
 FRAME_TIMESTAMP_INDEX = 0
 FRAME_IDENTIFIER_INDEX = 1

--- a/nixnet/_session/collection.py
+++ b/nixnet/_session/collection.py
@@ -91,8 +91,9 @@ class Collection(Sequence):
         if isinstance(other, self.__class__):
             other_collection = typing.cast(Collection, other)
             return (
-                self._handle == other_collection._handle and
-                self._list_cache == other_collection._list_cache)
+                self._handle == other_collection._handle
+                and self._list_cache == other_collection._list_cache
+            )
         else:
             return NotImplemented
 
@@ -132,8 +133,9 @@ class Item(object):
         if isinstance(other, self.__class__):
             other_item = typing.cast(Item, other)
             return (
-                self._handle == other_item._handle and
-                self._index == other_item._index)
+                self._handle == other_item._handle
+                and self._index == other_item._index
+            )
         else:
             return NotImplemented
 

--- a/nixnet/_utils.py
+++ b/nixnet/_utils.py
@@ -3,7 +3,7 @@ from __future__ import division
 from __future__ import print_function
 
 try:
-    from collections.abc import Iterable # python 3.3+
+    from collections.abc import Iterable  # python 3.3+
 except ImportError:
     from collections import Iterable  # python 2.7
 import typing  # NOQA: F401

--- a/nixnet/system/_collection.py
+++ b/nixnet/system/_collection.py
@@ -3,9 +3,11 @@ from __future__ import division
 from __future__ import print_function
 
 try:
-    from collections.abc import Iterable, Sized  # python 3.3+
+    from collections.abc import Iterable  # python 3.3+
+    from collections.abc import Sized  # python 3.3+
 except ImportError:
-    from collections import Iterable, Sized  # python 2.7
+    from collections import Iterable  # python 2.7
+    from collections import Sized  # python 2.7
 import typing  # NOQA: F401
 
 from nixnet import _cprops

--- a/nixnet_examples/programmatic_database_usage.py
+++ b/nixnet_examples/programmatic_database_usage.py
@@ -64,5 +64,6 @@ def main():
     with system.System() as my_system:
         del my_system.databases[database_name]
 
+
 if __name__ == '__main__':
     main()

--- a/requirements_test.in
+++ b/requirements_test.in
@@ -1,6 +1,5 @@
 # Test dependencies
 pytest
-mock
 pytest-cov
 coverage
 

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -38,12 +38,8 @@ mccabe==0.2.1
     # via
     #   flake8
     #   hacking
-mock==2.0.0
-    # via -r requirements_test.in
 pbr==3.1.1
-    # via
-    #   hacking
-    #   mock
+    # via hacking
 pep8==1.5.7
     # via
     #   flake8
@@ -73,7 +69,6 @@ requests==2.20.0
 six==1.10.0
     # via
     #   hacking
-    #   mock
     #   sphinx
 snowballstemmer==1.2.1
     # via sphinx

--- a/tests/test_dbc_attributes.py
+++ b/tests/test_dbc_attributes.py
@@ -2,9 +2,9 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import mock  # type: ignore
 import os
 import pytest  # type: ignore
+from unittest import mock  # type: ignore
 
 from nixnet import _cfuncs
 from nixnet import _ctypedefs

--- a/tests/test_dbc_signal_value_table.py
+++ b/tests/test_dbc_signal_value_table.py
@@ -2,9 +2,9 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import mock  # type: ignore
 import os
 import pytest  # type: ignore
+from unittest import mock  # type: ignore
 
 from nixnet import _cfuncs
 from nixnet import _ctypedefs

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import mock  # type: ignore
+from unittest import mock  # type: ignore
 
 import pytest  # type: ignore
 

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -3,7 +3,7 @@ from __future__ import division
 from __future__ import print_function
 
 import copy
-import mock  # type: ignore
+from unittest import mock  # type: ignore
 
 import pytest  # type: ignore
 

--- a/tests/test_frames.py
+++ b/tests/test_frames.py
@@ -4,7 +4,7 @@ from __future__ import print_function
 
 import time
 
-import mock  # type: ignore
+from unittest import mock  # type: ignore
 
 import pytest  # type: ignore
 

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -2,9 +2,9 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import mock  # type: ignore
 import pytest  # type: ignore
 import time
+from unittest import mock  # type: ignore
 
 import nixnet
 from nixnet import _cfuncs


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nixnet-python/blob/main/CONTRIBUTING.rst).
~- [ ] New tests have been created for any new features or regression tests for bugfixes.~
- [x] `tox` successfully runs, including unit tests and style checks (see [CONTRIBUTING.md](https://github.com/ni/nixnet-python/blob/main/CONTRIBUTING.rst)).

### What does this Pull Request accomplish?

This PR is to fix the existing flake8 warnings that are generated from running `tox -e flake8`.

### Why should this Pull Request be merged?

This PR fixes the existing flake8 warnings so that `tox` can be successfully run.

### What testing has been done?

Successfully run `tox` with Python 3.7.9 (there are some existing issues with running tox with Python 3.4 or older and Python 3.8 or newer (requires upgraded dependencies).