### PR TITLE
Fix Pytest warnings with `pytest 8.3.5`

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,6 +26,10 @@ def pytest_addoption(parser):
         help="The LIN interface to use with the tests")
 
 
+def pytest_configure(config):
+    config.addinivalue_line("markers", "integration: Integration test.")
+
+
 @pytest.fixture
 def can_in_interface(request):
     interface = request.config.getoption("--can-in-interface")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,10 +26,6 @@ def pytest_addoption(parser):
         help="The LIN interface to use with the tests")
 
 
-def pytest_configure(config):
-    config.addinivalue_line("markers", "integration: Integration test.")
-
-
 @pytest.fixture
 def can_in_interface(request):
     interface = request.config.getoption("--can-in-interface")

--- a/tox-integration.ini
+++ b/tox-integration.ini
@@ -25,3 +25,5 @@ passenv =
 
 [pytest]
 addopts = --cov nixnet --cov nixnet_examples --cov-report term --cov-report xml --verbose --doctest-modules --ignore=setup.py
+markers =
+    integration: Integration test.

--- a/tox.ini
+++ b/tox.ini
@@ -64,6 +64,8 @@ ignore = H903
 
 [pytest]
 addopts = --cov nixnet --cov nixnet_examples --cov-report term --cov-report xml --verbose --doctest-modules --ignore=setup.py
+markers =
+    integration: Integration test.
 
 [travis]
 python =


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nixnet-python/blob/main/CONTRIBUTING.rst).
~- [ ] New tests have been created for any new features or regression tests for bugfixes.~
- [x] `tox` successfully runs, including unit tests and style checks (see [CONTRIBUTING.md](https://github.com/ni/nixnet-python/blob/main/CONTRIBUTING.rst)).

### What does this Pull Request accomplish?

This PR is to fix the pytest-related warnings that will arise when the Pytest dependency is upgraded to 8.3.5 for newer Python versions.

It fixes the error in the form of:
```
PytestUnknownMarkWarning: Unknown pytest.mark.integration - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
    @pytest.mark.integration
```

### Why should this Pull Request be merged?

This PR is part of a series of PRs to prepare for supporting newer Python versions.

### What testing has been done?

- Locally run `tox` successfully with Python 3.7.9 (there are some existing issues with running tox with Python 3.4 or older and Python 3.8 or newer (requires upgraded dependencies)
- Locally run `tox -e test` with Python 3.11.9 with locally upgraded dependencies, no warnings were reported.
