### PR TITLE
Fix flake8 W503 error and remove H903 from flake8 ignore list

### DIFF
--- a/nixnet/_session/collection.py
+++ b/nixnet/_session/collection.py
@@ -85,7 +85,7 @@ class Collection(Sequence):
             other_collection = typing.cast(Collection, other)
             return (
                 self._handle == other_collection._handle
-                and self._list_cache == other_collection._list_cache
+                and self._list_cache == other_collection._list_cache  # NOQA: W503
             )
         else:
             return NotImplemented
@@ -127,7 +127,7 @@ class Item(object):
             other_item = typing.cast(Item, other)
             return (
                 self._handle == other_item._handle
-                and self._index == other_item._index
+                and self._index == other_item._index  # NOQA: W503
             )
         else:
             return NotImplemented

--- a/nixnet/_session/collection.py
+++ b/nixnet/_session/collection.py
@@ -85,7 +85,7 @@ class Collection(Sequence):
             other_collection = typing.cast(Collection, other)
             return (
                 self._handle == other_collection._handle
-                and self._list_cache == other_collection._list_cache  # NOQA: W503
+                and self._list_cache == other_collection._list_cache
             )
         else:
             return NotImplemented
@@ -127,7 +127,7 @@ class Item(object):
             other_item = typing.cast(Item, other)
             return (
                 self._handle == other_item._handle
-                and self._index == other_item._index  # NOQA: W503
+                and self._index == other_item._index
             )
         else:
             return NotImplemented

--- a/tox.ini
+++ b/tox.ini
@@ -59,8 +59,8 @@ show_source = true
 # 120 for readability in certain cases
 max_line_length = 120
 exclude = build,docs,.tox,__pycache__
-# H903: Windows style line endings not allowed in code
-ignore = H903
+# W503: Line break occurred before a binary operator
+ignore = W503
 
 [pytest]
 addopts = --cov nixnet --cov nixnet_examples --cov-report term --cov-report xml --verbose --doctest-modules --ignore=setup.py


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nixnet-python/blob/main/CONTRIBUTING.rst).
~- [ ] New tests have been created for any new features or regression tests for bugfixes.~
- [x] `tox` successfully runs, including unit tests and style checks (see [CONTRIBUTING.md](https://github.com/ni/nixnet-python/blob/main/CONTRIBUTING.rst)).

### What does this Pull Request accomplish?

This PR is to fix the flake8 W503 (Line break occurred before a binary operator) error that will be thrown when the `flake8` dependency is upgraded to `v7.1.2` to support newer Python versions.

`W503` conflicts with `W504` (Line break occurred after a binary operator), hence we'll need to disable one of them. This PR adds `W503` to the flake8 ignore list in tox.ini.

This PR also removes `H903: Windows style line endings not allowed in code` from the existing flake8 ignore list since [this error code does not seem to be valid](https://www.flake8rules.com/).

### Why should this Pull Request be merged?

This PR is part of a series of PRs to prepare for supporting newer Python versions.

### What testing has been done?

- Locally run `tox` successfully with Python 3.7.9
- Locally run `tox` successfully with Python 3.11.9 with locally upgraded dependencies