### PR TITLE
Release 1.0.0: Add Python support up to 3.13, drop EOL'ed Python support

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2017-2018, National Instruments Corp.
+Copyright (c) 2017-2025, National Instruments Corp.
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the

--- a/README.rst
+++ b/README.rst
@@ -48,7 +48,7 @@ of NI-XNET.
 
 **nixnet** can be installed with `pip <http://pypi.python.org/pypi/pip>`__::
 
-  $ python -m pip install nixnet~=0.3.2
+  $ python -m pip install nixnet~=1.0.0
 
 Now you should be able to move onto the `Examples <https://github.com/ni/nixnet-python/tree/main/nixnet_examples>`__.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "nixnet"
-version = "0.3.2"
+version = "1.0.0"
 description = "NI-XNET Python API"
 authors = ["NI <opensource@ni.com>"]
 license = "MIT"


### PR DESCRIPTION
Breaking Changes

- Drop Python 2 support ([5876a41])
- Drop Python 3.4 - 3.8 support ([ee8e23d])

Bug Fixes

- Support for Python 3.10 ([ee8e23d], closes [#290])

Features

- Add Python 3.10 - 3.13 support ([ee8e23d])