### PR TITLE
Add .readthedocs.yaml to configure readthedocs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,25 @@
+# Read the Docs configuration file for Sphinx projects
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+  jobs:
+    post_create_environment:
+      - pip install --upgrade poetry
+    post_install:
+      # VIRTUAL_ENV needs to be set manually for now.
+      # See https://github.com/readthedocs/readthedocs.org/pull/11152/
+      - VIRTUAL_ENV=$READTHEDOCS_VIRTUALENV_PATH poetry sync --with docs
+
+# Build documentation in the "docs/" directory with Sphinx
+sphinx:
+  configuration: docs/conf.py
+
+formats:
+  - pdf
+  - epub


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nixnet-python/blob/main/CONTRIBUTING.rst).
~- [ ] New tests have been created for any new features or regression tests for bugfixes.~
~- [ ] `tox` successfully runs, including unit tests and style checks (see [CONTRIBUTING.md](https://github.com/ni/nixnet-python/blob/main/CONTRIBUTING.rst)).~

### What does this Pull Request accomplish?

This PR adds a `.readthedocs.yaml` file at the root level of the repo, which is created based on the [official template provided by readthedocs.org](https://docs.readthedocs.com/platform/stable/config-file/index.html).

### Why should this Pull Request be merged?

This new file is required to configure [readthedocs to build documentations for nixnet correctly](https://app.readthedocs.org/projects/nixnet/).

### What testing has been done?

N/A