### PR TITLE
Update .readthedocs.yaml to use `poetry install` instead of `poetry sync`

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -14,7 +14,7 @@ build:
     post_install:
       # VIRTUAL_ENV needs to be set manually for now.
       # See https://github.com/readthedocs/readthedocs.org/pull/11152/
-      - VIRTUAL_ENV=$READTHEDOCS_VIRTUALENV_PATH poetry sync --with docs
+      - VIRTUAL_ENV=$READTHEDOCS_VIRTUALENV_PATH poetry install --with docs
 
 # Build documentation in the "docs/" directory with Sphinx
 sphinx:


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nixnet-python/blob/main/CONTRIBUTING.rst).
~- [ ] New tests have been created for any new features or regression tests for bugfixes.~
~- [ ] `tox` successfully runs, including unit tests and style checks (see [CONTRIBUTING.md](https://github.com/ni/nixnet-python/blob/main/CONTRIBUTING.rst)).~

### What does this Pull Request accomplish?

- Attempt to fix the [readthedocs build failure](https://app.readthedocs.org/projects/nixnet/builds/29448988/) by updating `.readthedocs.yaml` to run `poetry install --with docs` instead of `poetry sync --with docs` as `poetry sync` would uninstall poetry and cause failure

### Why should this Pull Request be merged?

- To fix readthedocs build failure.

### What testing has been done?

- Pending readthedocs build