### PR TITLE
Update .readthedocs.yaml to support all formats

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -20,6 +20,5 @@ build:
 sphinx:
   configuration: docs/conf.py
 
-formats:
-  - pdf
-  - epub
+# Build all formats supported by Sphinx (htmlzip, pdf, epub)
+formats: all


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nixnet-python/blob/main/CONTRIBUTING.rst).
~- [ ] New tests have been created for any new features or regression tests for bugfixes.~
~- [ ] `tox` successfully runs, including unit tests and style checks (see [CONTRIBUTING.md](https://github.com/ni/nixnet-python/blob/main/CONTRIBUTING.rst)).~

### What does this Pull Request accomplish?

- Update the `formats` option in .readthedocs.yaml from `pdf` and `epub` to `all` so that `htmlzip` is also supported (the existing readthedocs page for `nixnet` supports all three formats)
<img width="845" height="487" alt="image" src="https://github.com/user-attachments/assets/79e790bc-9b0e-4b78-a398-6cf8e6d66619" />

### Why should this Pull Request be merged?

To restore parity with the existing documentation for `nixnet` Python package.

### What testing has been done?

Pending the rebuild of the readthedocs project with the latest `.readthedocs.yaml`
